### PR TITLE
Only parse and print ICMP reply messages

### DIFF
--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -95,8 +95,6 @@ class IcmpV6Factory(object):
         ulpf={
             58: ipv6.ICMPv6Factory(
                 body_factories={
-                    0: ipv6.ICMPv6DestinationUnreachableFactory(),
-                    128: ipv6.ICMPv6EchoBodyFactory(),
                     129: ipv6.ICMPv6EchoBodyFactory()
                 }
             )


### PR DESCRIPTION
It helps to fix the `ncp-sim` travis check failures on OT master, the test scripts mistook the previous ICMP request message as the expected ICMP reply message: https://travis-ci.org/openthread/openthread/jobs/233462783#L1667