### PR TITLE
[codec] Fix the parsing of `STREAM_NET` and `STREAM_NET_INSECURE` spinel properties

### DIFF
--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -274,7 +274,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             consumed = True
 
             try:
-                pkt = cls.icmp_factory.from_bytes(value[2:])
+                pkt = cls.icmp_factory.from_bytes(value)
 
                 if CONFIG.DEBUG_LOG_PKT:
                     logging.debug(pkt)

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -119,7 +119,7 @@ class SpinelCodec(object):
     def parse_D(cls, payload): return payload
 
     @classmethod
-    def parse_d(cls, payload): return payload[2:unpack("<H", payload[:2])[0]]
+    def parse_d(cls, payload): return payload[2:2+unpack("<H", payload[:2])[0]]
 
     @classmethod
     def parse_i(cls, payload):
@@ -667,9 +667,9 @@ class SpinelPropertyHandler(SpinelCodec):
 
     def STREAM_RAW(self, _, payload): return self.parse_D(payload)
 
-    def STREAM_NET(self, _, payload): return self.parse_D(payload)
+    def STREAM_NET(self, _, payload): return self.parse_d(payload)
 
-    def STREAM_NET_INSECURE(self, _, payload): return self.parse_D(payload)
+    def STREAM_NET_INSECURE(self, _, payload): return self.parse_d(payload)
 
     def PIB_PHY_CHANNELS_SUPPORTED(self, _wpan_api, payload): pass
 


### PR DESCRIPTION
The `STREAM_NET` (secure or insecure) can contain an optional metadata
portion after the message payload. This commit ensures these properties
are parsed/unpacked correctly when the metadata is present.