### PR TITLE
[sniffer] rename "--ti-crc" to "--crc"

### DIFF
--- a/SNIFFER.md
+++ b/SNIFFER.md
@@ -80,8 +80,8 @@ sudo pip install --user ipaddress
     -c, --channel
         Set the channel upon which to listen.
 
-    --ti-crc
-        Recalculate crc for NCP sniffer on TI platform.
+    --crc
+        Recalculate crc for NCP sniffer (useful for platforms that do not provide the crc).
 ```
 
 ## Quick Start
@@ -92,7 +92,7 @@ From openthread root:
     sudo ./tools/spinel-cli/sniffer.py -c 11 -n 1 -u /dev/ttyUSB0 | wireshark -k -i -
 
     For TI NCP sniffer
-    sudo ./tools/spinel-cli/sniffer.py -c 11 -n 1 --ti-crc -u /dev/ttyUSB0 | wireshark -k -i -
+    sudo ./tools/spinel-cli/sniffer.py -c 11 -n 1 --crc -u /dev/ttyUSB0 | wireshark -k -i -
 ```
 
 This will connect to stock openthread ncp firmware over the given UART,

--- a/sniffer.py
+++ b/sniffer.py
@@ -65,8 +65,8 @@ def parse_args():
     opt_parser.add_option("-c", "--channel", action="store",
                           dest="channel", type="int", default=DEFAULT_CHANNEL)
 
-    opt_parser.add_option('--ti-crc', action='store_true',
-                          dest='ti_crc', default=False )
+    opt_parser.add_option('--crc', action='store_true',
+                          dest='crc', default=False )
 
     return opt_parser.parse_args(args)
 
@@ -84,10 +84,8 @@ def sniffer_init(wpan_api, options):
     wpan_api.prop_set_value(SPINEL.PROP_NET_IF_UP, 1)
 
 
-def ti_crc( s ):
-    # TI Chips do not transmit the CRC
-    # See the data sheet for more details.
-    # Here we recalculate the CRC ...
+def crc( s ):
+    # Some chips do not transmit the CRC, here we recalculate the CRC.
 
     crc = 0
     # remove the last 2 bytes
@@ -148,8 +146,8 @@ def main():
             if result and result.prop == prop_id:
                 length = wpan_api.parse_S(result.value)
                 pkt = result.value[2:2+length]
-                if options.ti_crc:
-                    pkt = ti_crc(pkt)
+                if options.crc:
+                    pkt = crc(pkt)
                 pkt = pcap.encode_frame(pkt)
                 if options.hex:
                     pkt = util.hexify_str(pkt)+"\n"


### PR DESCRIPTION
Not only TI's chip don't transmit CRC, some other platforms also don't, for example: nRF52840.