### PR TITLE
[codec] ensure to use the struct len when iterating/parsing through list of on-mesh-prefixes

### DIFF
--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -561,6 +561,7 @@ class SpinelPropertyHandler(SpinelCodec):
         slaacPrefixSet = set()
         while len(pay) >= 22:
             (_structlen) = unpack('<H', pay[:2])
+            struct_len = _structlen[0]
             pay = pay[2:]
             prefix = Prefix(*unpack('16sBBBB', pay[:20]))
             if prefix.flags & kThread.PrefixSlaacFlag:
@@ -568,7 +569,7 @@ class SpinelPropertyHandler(SpinelCodec):
                 net6 = net6.supernet(new_prefix=prefix.prefixlen)
                 slaacPrefixSet.add(net6)
                 prefixes.append(prefix)
-            pay = pay[20:]
+            pay = pay[struct_len:]
 
         for prefix in prefixes:
             self.handle_ipaddr_insert(*prefix)


### PR DESCRIPTION
This change removes the hard-coded length value and replaces it with the `struct_len` derived from the spinel frame.

This should address the failing tests from https://github.com/openthread/openthread/pull/2073