### PR TITLE
[sniffer] add set uart baud rate option

### DIFF
--- a/SNIFFER.md
+++ b/SNIFFER.md
@@ -43,6 +43,9 @@ sudo pip install --user ipaddress
        	Open a serial connection to the OpenThread NCP device
 	where <UART> is a device path such as "/dev/ttyUSB0".
 
+    -b <baudrate>, --baudrate=<baudrate>
+        Set the uart baud rate, default is 115200.
+
     -p <PIPE>, --pipe=<PIPE>
         Open a piped process connection to the OpenThread NCP device
         where <PIPE> is the command to start an emulator, such as
@@ -92,9 +95,9 @@ make the node into a promiscuous mode sniffer on the given channel,
 open up wireshark, and start streaming packets into wireshark.
 
 ## Troubleshooting
-Q: sniffer.py throws ```ImportError: No module named dnet``` on OSX
+Q1: sniffer.py throws ```ImportError: No module named dnet``` on OSX
 
-A: install the libdnet package for OSX -
+A1: install the libdnet package for OSX -
 ```
 brew install --with-python libdnet
 mkdir -p /Users/YourUsernameHere/Library/Python/2.7/lib/python/site-packages
@@ -104,3 +107,10 @@ echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >>
 you may need to reinstall the scapy pip dependency listed above
 
 you can read more about this issue here: http://stackoverflow.com/questions/26229057/scapy-installation-fails-on-osx-with-dnet-import-error
+
+
+Q2: high packet loss rate when sniffing heavy traffic
+
+A2: use higher uart baud rate in Sniffer firmware(NCP), and use '-b <baudrate>' option to set the same baud rate on host side.
+
+to avoid packet loss, the baud rate should be higher than 250kbps, which is the maximum bitrate of the 802.15.4 2.4GHz PHY

--- a/sniffer.py
+++ b/sniffer.py
@@ -41,6 +41,7 @@ from spinel.pcap import PcapCodec
 # This is maximum that works for MacOS.
 DEFAULT_NODEID = 34    # same as WELLKNOWN_NODE_ID
 DEFAULT_CHANNEL = 11
+DEFAULT_BAUDRATE = 115200
 
 def parse_args():
     """ Parse command line arguments for this applications. """
@@ -50,6 +51,8 @@ def parse_args():
     opt_parser = optparse.OptionParser()
     opt_parser.add_option("-u", "--uart", action="store",
                           dest="uart", type="string")
+    opt_parser.add_option("-b", "--baudrate", action="store",
+                          dest="baudrate", type="int", default=DEFAULT_BAUDRATE)
     opt_parser.add_option("-p", "--pipe", action="store",
                           dest="pipe", type="string")
     opt_parser.add_option("-s", "--socket", action="store",
@@ -135,7 +138,7 @@ def main():
         if len(remaining_args) > 0:
             stream_descriptor = " ".join(remaining_args)
 
-    stream = StreamOpen(stream_type, stream_descriptor, False)
+    stream = StreamOpen(stream_type, stream_descriptor, False, options.baudrate)
     if stream is None: exit()
     wpan_api = WpanApi(stream, options.nodeid)
     result = sniffer_init(wpan_api, options)

--- a/spinel/stream.py
+++ b/spinel/stream.py
@@ -124,7 +124,7 @@ class StreamPipe(IStream):
             self.pipe = None
 
 
-def StreamOpen(stream_type, descriptor, verbose=True):
+def StreamOpen(stream_type, descriptor, verbose=True, baudrate=115200):
     """
     Factory function that creates and opens a stream connection.
 
@@ -153,7 +153,6 @@ def StreamOpen(stream_type, descriptor, verbose=True):
 
     elif stream_type == 'u':
         dev = str(descriptor)
-        baudrate = 115200
         if verbose:
             print("Opening serial to " + dev + " @ " + str(baudrate))
         return StreamSerial(dev, baudrate)


### PR DESCRIPTION
Some backgrounds:
- The 802.15.4 PHY throughput used by Thread is 250kbps;
- Most of existing OT platforms uart baud rate is 115200;
- Current ncp_uart doesn't support buffer mechanism (single UartTxBuffer).

If there are two packets come from Thread network with very short interval, the second packet may be lost since the previous one is still in the UartTxBuffer sending from NCP to host.

The issue becomes more serious for OT Sniffer when sniffing heavy traffic.

Similar description in [draft-rquattle-spinel-unified.txt](https://github.com/openthread/openthread/blob/master/doc/draft-rquattle-spinel-unified.txt#L3768.)