### PR TITLE
Fix incorrect NET_STACK_UP set value

### DIFF
--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -1699,13 +1699,11 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         map_arg_value = {
             0: "stop",
             1: "start",
-            2: "start",
-            3: "start",
         }
 
         map_arg_name = {
             "stop": "0",
-            "start": "2",
+            "start": "1",
         }
 
         if line:


### PR DESCRIPTION
The `NET_STACK_UP` expects a `boolean` value which should be encoded
as 0x00 (for `false`)  and 0x01 (for `true`) per Spinel specification
This commit fixes an issue where value `2` was used for `true`
incorrectly for the `NET_STACK_UP` set operation.