### PR TITLE
Add no-reset cli parameter to the sniffer.py to skip NCP reset on init

### DIFF
--- a/SNIFFER.md
+++ b/SNIFFER.md
@@ -80,6 +80,9 @@ sudo pip install --user ipaddress
     --crc
         Recalculate crc for NCP sniffer (useful for platforms that do not provide the crc).
 
+    --no_reset
+        Do not reset the NCP during initialization (useful for some NCPs with the native USB connection).
+
     --rssi
         Include RSSI information in pcap output.
 ```
@@ -94,6 +97,9 @@ sudo pip install --user ipaddress
 
     For the sniffers that do not provide the crc:
     sudo ./sniffer.py -c 11 -n 1 --crc -u /dev/ttyUSB0 | wireshark -k -i -
+
+    For the sniffers that are connected to the host with the native USB connection and reset during init results in failed start:
+    sudo ./sniffer.py -c 11 -n 1 --no_reset -u /dev/ttyUSB0 | wireshark -k -i -
 
     To display RSSI on Wireshark:
     1. Configue Wireshark:

--- a/SNIFFER.md
+++ b/SNIFFER.md
@@ -80,7 +80,7 @@ sudo pip install --user ipaddress
     --crc
         Recalculate crc for NCP sniffer (useful for platforms that do not provide the crc).
 
-    --no_reset
+    --no-reset
         Do not reset the NCP during initialization (useful for some NCPs with the native USB connection).
 
     --rssi
@@ -99,7 +99,7 @@ sudo pip install --user ipaddress
     sudo ./sniffer.py -c 11 -n 1 --crc -u /dev/ttyUSB0 | wireshark -k -i -
 
     For the sniffers that are connected to the host with the native USB connection and reset during init results in failed start:
-    sudo ./sniffer.py -c 11 -n 1 --no_reset -u /dev/ttyUSB0 | wireshark -k -i -
+    sudo ./sniffer.py -c 11 -n 1 --no-reset -u /dev/ttyUSB0 | wireshark -k -i -
 
     To display RSSI on Wireshark:
     1. Configue Wireshark:

--- a/sniffer.py
+++ b/sniffer.py
@@ -73,7 +73,7 @@ def parse_args():
     opt_parser.add_option('--rssi', action='store_true',
                           dest='rssi', default=False )
 
-    opt_parser.add_option('--no_reset', action='store_true',
+    opt_parser.add_option('--no-reset', action='store_true',
                           dest='no_reset', default=False )
 
     return opt_parser.parse_args(args)

--- a/sniffer.py
+++ b/sniffer.py
@@ -73,6 +73,9 @@ def parse_args():
     opt_parser.add_option('--rssi', action='store_true',
                           dest='rssi', default=False )
 
+    opt_parser.add_option('--no_reset', action='store_true',
+                          dest='no_reset', default=False )
+
     return opt_parser.parse_args(args)
 
 def sniffer_init(wpan_api, options):
@@ -81,8 +84,10 @@ def sniffer_init(wpan_api, options):
     wpan_api.queue_register(SPINEL.HEADER_ASYNC)
 
     sys.stderr.write("Initializing sniffer...\n")
-    wpan_api.cmd_send(SPINEL.CMD_RESET)
-    time.sleep(1)
+
+    if not options.no_reset:
+        wpan_api.cmd_send(SPINEL.CMD_RESET)
+        time.sleep(1)
 
     result = wpan_api.prop_set_value(SPINEL.PROP_PHY_ENABLED, 1)
 


### PR DESCRIPTION
This PR adds new --no_reset flag to the spinner.py CLI.
Resetting the NCP with native USB conenction causes it to reenumerate and, as result, not start properly.
In that case adding the mentioned flag makes the sniffer fully funcional.

Signed-off-by: Piotr Szkotak piotr.szkotak@nordicsemi.no