### PR TITLE
Added support for storing capture in a file

### DIFF
--- a/SNIFFER.md
+++ b/SNIFFER.md
@@ -31,7 +31,7 @@ sudo pip install --user ipaddress
     sniffer.py - shell tool for controlling OpenThread NCP instances
 
 ### SYNOPSIS
-    sniffer.py [-hupsnqvdxc]
+    sniffer.py [-hupsnqvdxco]
 
 ### DESCRIPTION
 
@@ -76,6 +76,9 @@ sudo pip install --user ipaddress
 
     -c, --channel
         Set the channel upon which to listen.
+
+    -o <FILE_NAME>, --output=<FILE_NAME>
+        Write capture to a file named <FILE_NAME>
 
     --crc
         Recalculate crc for NCP sniffer (useful for platforms that do not provide the crc).

--- a/sniffer.py
+++ b/sniffer.py
@@ -63,6 +63,8 @@ def parse_args():
     opt_parser.add_option("-d", "--debug", action="store",
                           dest="debug", type="int", default=CONFIG.DEBUG_ENABLE)
     opt_parser.add_option("-x", "--hex", action="store_true", dest="hex")
+    opt_parser.add_option("-o", "--output", action="store",
+                          dest="output", type="string")
 
     opt_parser.add_option("-c", "--channel", action="store",
                           dest="channel", type="int", default=DEFAULT_CHANNEL)
@@ -156,8 +158,14 @@ def main():
     hdr = pcap.encode_header()
     if options.hex:
         hdr = util.hexify_str(hdr)+"\n"
-    sys.stdout.write(hdr)
-    sys.stdout.flush()
+    
+    if (options.output):
+        output = open(options.output, 'wb')
+    else:
+        output = sys.stdout
+
+    output.write(hdr)
+    output.flush()
 
     epoch = datetime(1970, 1, 1)
     timebase = datetime.utcnow() - epoch
@@ -209,8 +217,8 @@ def main():
                 pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec)
                 if options.hex:
                     pkt = util.hexify_str(pkt)+"\n"
-                sys.stdout.write(pkt)
-                sys.stdout.flush()
+                output.write(pkt)
+                output.flush()
 
     except KeyboardInterrupt:
         pass
@@ -218,6 +226,7 @@ def main():
     if wpan_api:
         wpan_api.stream.close()
 
+    output.close()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
On Windows, redirecting sniffer output to a file doesn't work
properly due to new line characters processing. This commit
adds a separate option which allows for storing capture to
a file.

Signed-off-by: Wojciech Bober <wojciech.bober@nordicsemi.no>