### PR TITLE
[spinel-cli] Fixed bug with setting panid and extaddr

### DIFF
--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -354,8 +354,10 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         if line != None:
             if mixed_format == 'U':         # For UTF8, just a pass through line unmodified
                 value = line.encode('utf-8') + '\0'
-            elif mixed_format == 'D':     # Expect raw data to be hex string w/o delimeters
+            elif mixed_format == 'D' or mixed_format == 'E':      # Expect raw data to be hex string w/o
                 value = util.hex_to_bytes(line)
+            elif mixed_format == 'H':
+                value = util.hex_to_bytes(line[4:6] + line[2:4])
             else:
                 # Most everything else is some type of integer
                 value = int(line)
@@ -367,7 +369,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         py_format = mixed_format
         if value == "":
             py_format = '0s'
-        elif mixed_format == 'D' or mixed_format == 'U':
+        elif mixed_format == 'D' or mixed_format == 'U' or mixed_format == 'E' or mixed_format == 'H':
             py_format = str(len(value)) + 's'
         return py_format
 


### PR DESCRIPTION
There is an issue when trying to change panid via `spinel-cli.py`.

Steps to reproduce:
1. `./spinel-cli.py -u /dev/ttyUSB0
2. `panid 0xABCD`
3. Exception raised while casting `0xABCD` string to int.

It looks like ([python built-in functions documentation](https://docs.python.org/3/library/functions.html#int)) the `base` for int assumption can be only done if the `base` argument is set to *0*. So far there wasn't any value for `base` argument, so `0xABCD` was tried to cast to int with base equal *10*, which caused exception raise.