### PR TITLE
[spinel-cli] close simulated node elegantly

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -36,4 +36,4 @@ pip install --upgrade .
     cd openthread &&
     pip install -r tests/scripts/thread-cert/requirements.txt &&
     ./bootstrap &&
-    VERBOSE=1 NODE_TYPE=ncp-sim make -f examples/Makefile-posix check)
+    VIRTUAL_TIME=1 VERBOSE=1 NODE_TYPE=ncp-sim make -f examples/Makefile-posix check)

--- a/spinel/stream.py
+++ b/spinel/stream.py
@@ -109,7 +109,7 @@ class StreamPipe(IStream):
 
     def __del__(self):
         if self.pipe:
-            self.pipe.terminate()
+            self.pipe.stdin.close()
             self.pipe.wait()
             self.pipe = None
 

--- a/spinel/stream.py
+++ b/spinel/stream.py
@@ -108,10 +108,7 @@ class StreamPipe(IStream):
             traceback.print_exc()
 
     def __del__(self):
-        if self.pipe:
-            self.pipe.stdin.close()
-            self.pipe.wait()
-            self.pipe = None
+        self.close()
 
     def write(self, data):
         if CONFIG.DEBUG_STREAM_TX:
@@ -126,11 +123,14 @@ class StreamPipe(IStream):
         pkt = self.pipe.stdout.read(size)
         if CONFIG.DEBUG_STREAM_RX:
             logging.debug("RX Raw: " + str(map(spinel.util.hexify_chr, pkt)))
+        if not pkt:
+            sys.exit(0)
         return map(ord, pkt)[0]
 
     def close(self):
         if self.pipe:
-            self.pipe.kill()
+            self.pipe.stdin.close()
+            self.pipe.wait()
             self.pipe = None
 
 


### PR DESCRIPTION
* close node elegantly to recover code coverage.
* use virtual time to accelerate running tests.