### PR TITLE
Fix payload nullchar crash

### DIFF
--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -119,7 +119,10 @@ class SpinelCodec(object):
             nullchar = bytes([0])
         else:
             nullchar = '\0'
-        return payload[:payload.index(nullchar)]  # strip null
+        if payload.find(nullchar) >= 0:
+            return payload[:payload.index(nullchar)]  # strip null
+        else:
+            return payload
 
     @classmethod
     def parse_D(cls, payload): return payload


### PR DESCRIPTION
spinel-cli crashes when asking the version on a KW41Z-NCP node

```
spinel-cli > version
Traceback (most recent call last):
  File "/aprojects/rem-nxp/raspberry_pi/pyspinel-1.0.0a3/spinel/codec.py", line 950, in parse_rx
    handler(self, payload, tid)
  File "/aprojects/rem-nxp/raspberry_pi/pyspinel-1.0.0a3/spinel/codec.py", line 757, in PROP_VALUE_IS
    self.handle_prop(wpan_api, "IS", payload, tid)
  File "/aprojects/rem-nxp/raspberry_pi/pyspinel-1.0.0a3/spinel/codec.py", line 721, in handle_prop
    prop_value = handler(wpan_api, payload[prop_len:])
  File "/aprojects/rem-nxp/raspberry_pi/pyspinel-1.0.0a3/spinel/codec.py", line 406, in NCP_VERSION
    def NCP_VERSION(self, _, payload): return self.parse_U(payload)
  File "/aprojects/rem-nxp/raspberry_pi/pyspinel-1.0.0a3/spinel/codec.py", line 124, in parse_U
    return payload[:payload.index(nullchar)]  # strip null
ValueError: substring not found
```
Fixed the crash by checking first if the payload contains a nullcharacter 

