### PR TITLE
[sniffer] add '--tap' option

### DIFF
--- a/SNIFFER.md
+++ b/SNIFFER.md
@@ -88,6 +88,9 @@ sudo pip install --user ipaddress
 
     --rssi
         Include RSSI information in pcap output.
+    
+    --tap
+        Specify DLTs as IEEE802.15.4 TAP. Include Channel information in pcap output.
 ```
 
 ## Quick Start
@@ -113,6 +116,16 @@ sudo pip install --user ipaddress
             Fields:  wpan.rssi
     2. Run by command:
         sudo ./sniffer.py -c 11 -n 1 --rssi -u /dev/ttyUSB0 | wireshark -k -i -
+    
+    To display Channel on Wireshark: (only for Wireshark 3.0 and later)
+    1. Configue Wireshark:
+        Edit->Preferences->Appearance->Columns, add a new entry:
+            Title:   Channel
+            Type:    Custom
+            Fields:  wpan-tap.ch_num
+    2. Run by command:
+        sudo ./sniffer.py -c 11 --tap -u /dev/ttyUSB0 | wireshark -k -i -
+
 ```
 
 This will connect to stock openthread ncp firmware over the given UART,

--- a/SNIFFER.md
+++ b/SNIFFER.md
@@ -90,7 +90,8 @@ sudo pip install --user ipaddress
         Include RSSI information in pcap output.
     
     --tap
-        Specify DLTs as IEEE802.15.4 TAP. Include Channel information in pcap output.
+        Specify DLT_IEEE802_15_4_TAP(283) for frame format, with a pseudo-header containing TLVs with metadata (e.g. FCS, RSSI, LQI, channel etc). 
+        If not specified, DLT_IEEE802_15_4_WITHFCS(195) would be used by default with the additional RSSI, LQI following the PHY frame directly (TI style FCS format).
 ```
 
 ## Quick Start

--- a/sniffer.py
+++ b/sniffer.py
@@ -43,6 +43,9 @@ DEFAULT_NODEID = 34    # same as WELLKNOWN_NODE_ID
 DEFAULT_CHANNEL = 11
 DEFAULT_BAUDRATE = 115200
 
+DLT_IEEE802_15_4_WITHFCS = 195
+DLT_IEEE802_15_4_TAP = 283
+
 def parse_args():
     """ Parse command line arguments for this applications. """
 
@@ -163,7 +166,7 @@ def main():
         sys.stderr.write("SUCCESS: sniffer initialized\nSniffing...\n")
 
     pcap = PcapCodec()
-    hdr = pcap.encode_header(tap=options.tap)
+    hdr = pcap.encode_header(DLT_IEEE802_15_4_TAP if options.tap else DLT_IEEE802_15_4_WITHFCS)
 
     if options.hex:
         hdr = util.hexify_str(hdr)+"\n"
@@ -246,7 +249,7 @@ def main():
                         sys.stderr.write("WARNING: failed to display RSSI, please update the NCP version\n")
 
                 if options.tap:
-                    pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec, True, metadata)
+                    pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec, metadata)
                 else:
                     pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec)
 

--- a/sniffer.py
+++ b/sniffer.py
@@ -78,6 +78,9 @@ def parse_args():
     opt_parser.add_option('--no-reset', action='store_true',
                           dest='no_reset', default=False )
 
+    opt_parser.add_option('--tap', action='store_true',
+                          dest='tap', default=False)
+
     return opt_parser.parse_args(args)
 
 def sniffer_init(wpan_api, options):
@@ -160,7 +163,8 @@ def main():
         sys.stderr.write("SUCCESS: sniffer initialized\nSniffing...\n")
 
     pcap = PcapCodec()
-    hdr = pcap.encode_header()
+    hdr = pcap.encode_header(tap=options.tap)
+
     if options.hex:
         hdr = util.hexify_str(hdr)+"\n"
 
@@ -241,7 +245,11 @@ def main():
                         pkt = pkt[:-2] + chr(127) + chr(0x80)
                         sys.stderr.write("WARNING: failed to display RSSI, please update the NCP version\n")
 
-                pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec)
+                if options.tap:
+                    pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec, True, metadata)
+                else:
+                    pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec)
+
                 if options.hex:
                     pkt = util.hexify_str(pkt)+"\n"
                 output.write(pkt)

--- a/sniffer.py
+++ b/sniffer.py
@@ -113,22 +113,6 @@ def sniffer_init(wpan_api, options):
 
     return True
 
-# def crc( s ):
-#     # Some chips do not transmit the CRC, here we recalculate the CRC.
-# 
-#     crc = 0
-#     # remove the last 2 bytes
-#     for c in s[:-2]:
-#         c = ord(c)
-#         q = (crc ^ c) & 0x0f
-#         crc = (crc >> 4) ^ (q * 0x1081)
-#         q = (crc ^ (c >> 4)) & 0x0f
-#         crc = (crc >> 4) ^ (q * 0x1081)
-#     msb = chr( 0x0ff & (crc >> 8) )
-#     lsb = chr( 0x0ff & (crc >> 0) )
-#     s = s[:-2] + lsb + msb
-#     return s
-
 def main():
     """ Top-level main for sniffer host-side tool. """
     (options, remaining_args) = parse_args()

--- a/sniffer.py
+++ b/sniffer.py
@@ -178,8 +178,6 @@ def main():
             if result and result.prop == prop_id:
                 length = wpan_api.parse_S(result.value)
                 pkt = result.value[2:2+length]
-                # if options.crc:
-                #     pkt = crc(pkt)
 
                 # metadata format (totally 19 bytes):
                 # 0. RSSI(int8)
@@ -197,8 +195,6 @@ def main():
                     timestamp = metadata[3][2]
                     timestamp_sec = timestamp / 1000000
                     timestamp_usec = timestamp % 1000000
-
-                    rssi = chr(metadata[0] & 0xff) + chr(0x80)
 
                 # (deprecated) metadata format (totally 17 bytes):
                 # 0. RSSI(int8)
@@ -218,21 +214,16 @@ def main():
                     timestamp_sec = timebase_sec + timestamp_usec / 1000000
                     timestamp_usec = timestamp_usec % 1000000
 
-                    rssi = chr(metadata[0] & 0xff) + chr(0x80)
-
                 # Some old version NCP doesn't contain timestamp information in metadata
                 else:
                     timestamp = datetime.utcnow() - epoch
                     timestamp_sec = timestamp.days * 24 * 60 * 60 + timestamp.seconds
                     timestamp_usec = timestamp.microseconds
 
-                    rssi = chr(127) + chr(0x80)
-                    sys.stderr.write("WARNING: failed to display RSSI, please update the NCP version\n")
+                    if options.rssi:
+                        sys.stderr.write("WARNING: failed to display RSSI, please update the NCP version\n")
 
-                if options.tap:
-                    pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec, options.rssi, options.crc, rssi, metadata)
-                else:
-                    pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec, options.rssi, options.crc, rssi)
+                pkt = pcap.encode_frame(pkt, timestamp_sec, timestamp_usec, options.rssi, options.crc, metadata)
 
                 if options.hex:
                     pkt = util.hexify_str(pkt)+"\n"

--- a/spinel/pcap.py
+++ b/spinel/pcap.py
@@ -22,6 +22,8 @@ PCAP_MAGIC_NUMBER = 0xa1b2c3d4
 PCAP_VERSION_MAJOR = 2
 PCAP_VERSION_MINOR = 4
 
+DLT_IEEE802_15_4_WITHFCS = 195
+DLT_IEEE802_15_4_TAP = 283
 TLVS_LENGTH = 28
 RSS_TYPE = 1
 RSS_LEN = 4
@@ -49,14 +51,14 @@ class PcapCodec(object):
     def encode_frame(cls, frame, sec, usec, metadata=None):
         """ Returns a pcap encapsulation of the given frame. """
         # write frame pcap header
-        if cls._dlt:
+        if (cls._dlt == DLT_IEEE802_15_4_TAP):
             length = len(frame) + TLVS_LENGTH
         else:
             length = len(frame)
 
         pcap_frame = struct.pack("<LLLL", sec, usec, length, length)
 
-        if cls._dlt:
+        if (cls._dlt == DLT_IEEE802_15_4_TAP):
             # Append TLVs according to 802.15.4 TAP specification:
             # https://github.com/jkcko/ieee802.15.4-tap
             pcap_frame += struct.pack('<HH', 0, TLVS_LENGTH)

--- a/spinel/pcap.py
+++ b/spinel/pcap.py
@@ -72,13 +72,15 @@ class PcapCodec(object):
         # write frame pcap header
         TLVs_length = TLVS_LENGTH_DEFAULT
         
-        if options_rssi:
-            frame = frame[:-2] + rssi
-            TLVs_length += 8
-        
         if options_crc:
             frame = crc(frame)
             TLVs_length += 8
+            
+        if options_rssi:
+            if (cls._dlt == DLT_IEEE802_15_4_TAP):
+                TLVs_length += 8
+            else:
+                frame = frame[:-2] + rssi
             
         if (cls._dlt == DLT_IEEE802_15_4_TAP):
             length = len(frame) + TLVs_length

--- a/spinel/pcap.py
+++ b/spinel/pcap.py
@@ -22,21 +22,29 @@ PCAP_MAGIC_NUMBER = 0xa1b2c3d4
 PCAP_VERSION_MAJOR = 2
 PCAP_VERSION_MINOR = 4
 
+# https://www.tcpdump.org/linktypes.html
 DLT_IEEE802_15_4_WITHFCS = 195
 DLT_IEEE802_15_4_TAP = 283
+
+# Refer to the IEEE 802.15.4 TAP Link Type Specification on
+# https://github.com/jkcko/ieee802.15.4-tap
+# Default length of TAP Header and channel TLV
 TLVS_LENGTH_DEFAULT = 12
+CHANNEL_TYPE = 3
+CHANNEL_LEN = 3
+CHANNEL_PAGE = 0
 
-
+# FCS TLV (optional, depending on `--crc`)
 FCS_TYPE = 0
 FCS_LEN = 1
 FCS_16bitCRC = 1
+
+# RSSI TLV and LQI TLV (optional, depending on `--rssi`)
 RSS_TYPE = 1
 RSS_LEN = 4
 LQI_TYPE = 10
 LQI_LEN = 1
-CHANNEL_TYPE = 3
-CHANNEL_LEN = 3
-CHANNEL_PAGE = 0
+
 
 
 def crc( s ):


### PR DESCRIPTION
The **--tap** flag is used to specify DLTs as [IEEE802_15_4_TAP](https://github.com/jkcko/ieee802.15.4-tap).
The existing DLTs for IEEE 802.15.4 have versions for FCS, NOFCS, NONASK_PHY, and LINUX (address fields padded). The NONASK_PHY includes only fixed preamble bytes, and the FCS/NOFCS versions support for heuristic match for ZBOSS generated format again with some fixed fields.  The proposed format attempts to wrap up the different types into one and provide an extensible TLV format for capture devices to provide additional meta-data.
When capturing from multiple interfaces on different channels by Wireshark, users can see which channel each packet comes from.