### PR TITLE
[sniffer] better integrate with Wireshark

### DIFF
--- a/extcap_ot.bat
+++ b/extcap_ot.bat
@@ -1,0 +1,17 @@
+:rem  Copyright (c) 2019, The OpenThread Authors.
+:rem  All rights reserved.
+:rem
+:rem  Licensed under the Apache License, Version 2.0 (the "License");
+:rem  you may not use this file except in compliance with the License.
+:rem  You may obtain a copy of the License at
+:rem
+:rem  http://www.apache.org/licenses/LICENSE-2.0
+:rem
+:rem  Unless required by applicable law or agreed to in writing, software
+:rem  distributed under the License is distributed on an "AS IS" BASIS,
+:rem  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:rem  See the License for the specific language governing permissions and
+:rem  limitations under the License.
+:rem
+@echo off
+python "%~dp0extcap_ot.py"  %*

--- a/extcap_ot.bat
+++ b/extcap_ot.bat
@@ -14,4 +14,4 @@
 :rem  limitations under the License.
 :rem
 @echo off
-python "%~dp0extcap_ot.py"  %*
+py -3 "%~dp0extcap_ot.py"  %*

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import os
+import sys
+import tempfile
+import argparse
+import subprocess
+import threading
+
+from spinel.stream import StreamOpen
+from spinel.const import SPINEL
+from spinel.codec import WpanApi
+from serial.tools.list_ports import comports
+from enum import Enum
+
+# Nodeid is required to execute ot-ncp-ftd for its sim radio socket port.
+# This is maximum that works for MacOS.
+DEFAULT_NODEID = 34
+COMMON_BAUDRATE = [460800, 115200, 9600]
+
+class Config(Enum):
+    CHANNEL = 0
+    BAUDRATE = 1
+    TAP = 2
+
+def extcap_config(interface, option):
+    """List Configuration for the given interface"""
+    args = []
+    values = []
+    args.append((Config.CHANNEL.value, '--channel', 'Channel', 'IEEE 802.15.4 channel', 'selector', '{required=true}{default=11}'))
+    args.append((Config.TAP.value, '--tap', 'IEEE 802.15.4 TAP (only for Wireshark3.0 and later)', 'IEEE 802.15.4 TAP', 'boolflag', '{default=yes}'))
+
+    for arg in args:
+        print('arg {number=%d}{call=%s}{display=%s}{tooltip=%s}{type=%s}%s' % arg)
+
+    values = values + [(Config.CHANNEL.value, '%d' % i, '%d' % i, 'true' if i == 11 else 'false') for i in range(11, 27)]
+
+    for value in values:
+        print('value {arg=%d}{value=%s}{display=%s}{default=%s}' % value)
+
+def extcap_dlts(interface):
+    """List DLTs for the given interface"""
+    print('dlt {number=195}{name=IEEE802_15_4_WITHFCS}{display=IEEE 802.15.4 with FCS}')
+    print('dlt {number=283}{name=IEEE802_15_4_TAP}{display=IEEE 802.15.4 TAP}')
+
+def serialopen(interface,  __console__, DirtylogFile):
+    """
+    Open serial to indentify OpenThread sniffer
+    :param interface: string, eg: '/dev/ttyUSB0 - Zolertia Firefly platform', '/dev/ttyACM1 - nRF52840 OpenThread Device'
+    """
+    sys.stdout = DirtylogFile
+    sys.stderr = DirtylogFile
+    interface = str(interface).split()[0]
+    baudrate = None
+    result = None
+
+    for speed in COMMON_BAUDRATE:
+        stream = StreamOpen('u', interface, False, baudrate=speed)
+
+        wpan_api = WpanApi(stream, nodeid=DEFAULT_NODEID)
+        # result is None for NCP, not None for RCP
+        result = wpan_api.prop_set_value(SPINEL.PROP_PHY_ENABLED, 1) # detect baudrate
+
+        # result should not be None for both NCP and RCP
+        result = wpan_api.prop_get_value(SPINEL.PROP_CAPS) # confirm OpenThread Sniffer
+
+        # check whether or not is OpenThread Sniffer
+        stream.close()
+        if result is not None:
+            baudrate = speed
+            break
+
+    sys.stdout = __console__
+    sys.stderr = __console__
+
+    if baudrate is not None:
+        if sys.platform == 'win32':
+            # Wireshark only shows the value of key `display`('OpenThread Sniffer').
+            # Here intentionally appends interface in the end (e.g. 'OpenThread Sniffer: COM0').
+            print('interface {value=%s:%s}{display=OpenThread Sniffer %s}' % (interface, baudrate, interface))
+        else:
+            # On Linux or MacOS, wireshark will show the concatenation of the content of `display`
+            # and `interface` by default (e.g. 'OpenThread Sniffer: /dev/ttyACM0').
+            print('interface {value=%s:%s}{display=OpenThread Sniffer}' % (interface, baudrate))
+
+def extcap_interfaces():
+    """List available interfaces to capture from"""
+    __console__ = sys.stdout
+
+    DirtylogFile = open(os.path.join(tempfile.gettempdir(), 'dirtylog'), 'w')
+    print('extcap {version=1.0.0}{display=OpenThread Sniffer}{help=https://github.com/openthread/pyspinel}')
+
+    for interface in comports():
+        th = threading.Thread(target=serialopen, args=(interface, __console__, DirtylogFile))
+        th.setDaemon(True)
+        th.start()
+
+def extcap_capture(interface, fifo, control_in, control_out, channel, tap):
+    """Start the sniffer to capture packets"""
+    # baudrate = detect_baudrate(interface)
+    interface_port = str(interface).split(':')[0]
+    interface_baudrate = str(interface).split(':')[1]
+
+    cmd = ['sniffer.py', '-c', channel, '-u', interface_port, '--rssi', '-b', interface_baudrate, '-o', str(fifo)]
+    if tap:
+        cmd.append('--tap')
+
+    subprocess.Popen(cmd).wait()
+
+def extcap_close_fifo(fifo):
+    """"Close extcap fifo"""
+    # This is apparently needed to workaround an issue on Windows/macOS
+    # where the message cannot be read. (really?)
+    fh = open(fifo, 'wb', 0)
+    fh.close()
+
+
+if __name__ == '__main__':
+
+    # Capture options
+    parser = argparse.ArgumentParser(description='OpenThread Sniffer extcap plugin')
+
+    # Extcap Arguments
+    parser.add_argument('--extcap-interfaces', help='Provide a list of interfaces to capture from', action='store_true')
+    parser.add_argument('--extcap-interface', help='Provide the interface to capture from')
+    parser.add_argument('--extcap-dlts', help='Provide a list of dlts for the given interface', action='store_true')
+    parser.add_argument('--extcap-config', help='Provide a list of configurations for the given interface', action='store_true')
+    parser.add_argument('--extcap-reload-option', help='Reload elements for the given option')
+    parser.add_argument('--capture', help='Start the capture routine', action='store_true')
+    parser.add_argument('--fifo', help='Use together with capture to provide the fifo to dump data to')
+    parser.add_argument('--extcap-capture-filter', help='Used together with capture to provide a capture filter')
+    parser.add_argument('--extcap-control-in', help='Used to get control messages from toolbar')
+    parser.add_argument('--extcap-control-out', help='Used to send control messages to toolbar')
+    parser.add_argument('--extcap-version', help='Wireshark Version')
+
+    # Interface Arguments
+    parser.add_argument('--channel', help='IEEE 802.15.4 capture channel [11-26]')
+    parser.add_argument('--tap', help='IEEE 802.15.4 TAP (only for Wireshark3.0 and later)', action='store_true')
+
+    try:
+        args, unknown = parser.parse_known_args()
+    except argparse.ArgumentError as e:
+        parser.exit('ERROR_ARG: %s' % str(e))
+
+    if len(unknown) > 0:
+        parser.exit('Sniffer %d unknown arguments given: %s' % (len(unknown), unknown))
+
+    if len(sys.argv) == 0:
+        parser.print_help()
+        parser.exit('No arguments given!')
+
+    if not args.extcap_interfaces and args.extcap_interface is None:
+        parser.exit('An interface must be provided or the selection must be displayed')
+
+    if args.extcap_interfaces:
+        extcap_interfaces()
+        sys.exit(0)
+
+    if args.extcap_config:
+        extcap_config(args.extcap_interface, '')
+    elif args.extcap_dlts:
+        extcap_dlts(args.extcap_interface)
+    elif args.capture:
+        if args.fifo is None:
+            parser.exit('The fifo must be provided to capture')
+        try:
+            extcap_capture(args.extcap_interface, args.fifo, args.extcap_control_in, args.extcap_control_out, args.channel, args.tap)
+        except KeyboardInterrupt:
+            pass
+        except:
+            parser.exit('ERROR_INTERNAL')
+    else:
+        parser.print_help()
+        parser.exit('ERROR_USAGE')

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -47,7 +47,7 @@ def extcap_config(interface, option, extcap_version):
     values = []
     args.append((Config.CHANNEL.value, '--channel', 'Channel', 'IEEE 802.15.4 channel', 'selector', '{required=true}{default=11}'))
 
-    match = re.match(r'^(\d+)\.(\d+)$', extcap_version)
+    match = re.match(r'^(\d+)(\.\d+)*$', extcap_version)
     if match and int(match.group(1)) >= 3:
         args.append((Config.TAP.value, '--tap', 'IEEE 802.15.4 TAP (only for Wireshark3.0 and later)', 'IEEE 802.15.4 TAP', 'boolflag', '{default=yes}'))
 

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -139,7 +139,8 @@ def extcap_capture(interface, fifo, control_in, control_out, channel, tap):
         cmd = ['python', sniffer_py]
     else:
         cmd = ['sniffer.py']
-    cmd += ['-c', channel, '-u', interface_port, '--crc', '--rssi', '-b', interface_baudrate, '-o', str(fifo)]
+    cmd += ['-c', channel, '-u', interface_port, '--crc', '--rssi', '-b', interface_baudrate, '-o', str(fifo),
+            '--is-fifo']
     if tap:
         cmd.append('--tap')
 

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -140,7 +140,7 @@ def extcap_capture(interface, fifo, control_in, control_out, channel, tap):
     else:
         cmd = ['sniffer.py']
     cmd += ['-c', channel, '-u', interface_port, '--crc', '--rssi', '-b', interface_baudrate, '-o', str(fifo),
-            '--is-fifo']
+            '--is-fifo', '--use-host-timestamp']
     if tap:
         cmd.append('--tap')
 

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -84,8 +84,8 @@ def serialopen(interface, log_file):
     baudrate = None
 
     for speed in COMMON_BAUDRATE:
-        with _StreamCloser(StreamOpen('u', interface, False, baudrate=speed)) as stream:
-            wpan_api = WpanApi(stream, nodeid=DEFAULT_NODEID, timeout=0.1)
+        with _StreamCloser(StreamOpen('u', interface, False, baudrate=speed)) as stream, \
+                WpanApi(stream, nodeid=DEFAULT_NODEID, timeout=0.1) as wpan_api:
 
             # result should not be None for both NCP and RCP
             result = wpan_api.prop_get_value(SPINEL.PROP_CAPS)  # confirm OpenThread Sniffer
@@ -125,8 +125,8 @@ def extcap_capture(interface, fifo, control_in, control_out, channel, tap):
     interface_port = str(interface).split(':')[0]
     interface_baudrate = str(interface).split(':')[1]
 
-    with _StreamCloser(StreamOpen('u', interface_port, False, baudrate=int(interface_baudrate))) as stream:
-        wpan_api = WpanApi(stream, nodeid=DEFAULT_NODEID)
+    with _StreamCloser(StreamOpen('u', interface_port, False, baudrate=int(interface_baudrate))) as stream, \
+            WpanApi(stream, nodeid=DEFAULT_NODEID) as wpan_api:
         wpan_api.prop_set_value(SPINEL.PROP_PHY_ENABLED, 1)
 
     if sys.platform == 'win32':

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -121,7 +121,7 @@ def extcap_capture(interface, fifo, control_in, control_out, channel, tap):
         cmd = ['python', sniffer_py]
     else:
         cmd = ['sniffer.py']
-    cmd += ['-c', channel, '-u', interface_port, '--rssi', '-b', interface_baudrate, '-o', str(fifo)]
+    cmd += ['-c', channel, '-u', interface_port, '--crc', '--rssi', '-b', interface_baudrate, '-o', str(fifo)]
     if tap:
         cmd.append('--tap')
 

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -191,8 +191,8 @@ if __name__ == '__main__':
         try:
             with open(version_path, mode='r') as f:
                 extcap_version = f.read()
-        except Exception as e:
-            logging.exception(e)
+        except FileNotFoundError:
+            pass
 
     if len(unknown) > 0:
         parser.exit('Sniffer %d unknown arguments given: %s' % (len(unknown), unknown))

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -107,11 +107,15 @@ def extcap_interfaces():
     log_file = open(os.path.join(tempfile.gettempdir(), 'extcap_ot_interfaces.log'), 'w')
     print('extcap {version=1.0.0}{display=OpenThread Sniffer}{help=https://github.com/openthread/pyspinel}')
 
+    threads = []
     for interface in comports():
         th = threading.Thread(target=serialopen, args=(interface, console, log_file))
         th.daemon = True
+        threads.append(th)
         th.start()
-    time.sleep(0.5)
+    deadline = time.time() + 0.5
+    for th in threads:
+        th.join(timeout=deadline - time.time())
 
 def extcap_capture(interface, fifo, control_in, control_out, channel, tap):
     """Start the sniffer to capture packets"""

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -129,7 +129,11 @@ def extcap_capture(interface, fifo, control_in, control_out, channel, tap):
     interface_baudrate = str(interface).split(':')[1]
 
     if sys.platform == 'win32':
-        python_path = subprocess.Popen('where python', stdout=subprocess.PIPE, shell=True).stdout.readline().decode().strip()
+        python_path = subprocess.Popen(
+            'py -3 -c "import sys; print(sys.executable)"',
+            stdout=subprocess.PIPE,
+            shell=True,
+        ).stdout.readline().decode().strip()
         sniffer_py = os.path.join(os.path.dirname(python_path), 'Scripts', 'sniffer.py')
         cmd = ['python', sniffer_py]
     else:

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -85,8 +85,7 @@ def serialopen(interface, log_file):
 
     for speed in COMMON_BAUDRATE:
         with _StreamCloser(StreamOpen('u', interface, False, baudrate=speed)) as stream:
-            wpan_api = WpanApi(stream, nodeid=DEFAULT_NODEID)
-            wpan_api.timeout = 0.1
+            wpan_api = WpanApi(stream, nodeid=DEFAULT_NODEID, timeout=0.1)
 
             # result should not be None for both NCP and RCP
             result = wpan_api.prop_get_value(SPINEL.PROP_CAPS)  # confirm OpenThread Sniffer

--- a/extcap_ot.py
+++ b/extcap_ot.py
@@ -105,10 +105,13 @@ def extcap_interfaces():
     DirtylogFile = open(os.path.join(tempfile.gettempdir(), 'dirtylog'), 'w')
     print('extcap {version=1.0.0}{display=OpenThread Sniffer}{help=https://github.com/openthread/pyspinel}')
 
+    threads = []
     for interface in comports():
         th = threading.Thread(target=serialopen, args=(interface, __console__, DirtylogFile))
-        th.setDaemon(True)
         th.start()
+        threads.append(th)
+    for th in threads:
+        th.join()
 
 def extcap_capture(interface, fifo, control_in, control_out, channel, tap):
     """Start the sniffer to capture packets"""

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,23 @@
 #  limitations under the License.
 #
 from setuptools import setup, find_packages
-
 import sys
+import os
+
+WiresharkExtcapDir = ''
+
+if sys.platform.startswith('linux'):
+    WiresharkExtcapDir = os.popen('find /usr/ -type d -ipath *wireshark*extcap').read()
+    if WiresharkExtcapDir:
+        WiresharkExtcapDir = str(WiresharkExtcapDir).split()[0]
+elif sys.platform == 'darwin':
+    WiresharkExtcapDir = os.popen('find /Applications/ -type d -ipath *wireshark*extcap').read()
+    if WiresharkExtcapDir:
+        WiresharkExtcapDir = str(WiresharkExtcapDir).split()[0]
+elif sys.platform == 'win32':
+    WiresharkDir = input("Wireshark installation directory: ")
+    if WiresharkDir:
+        WiresharkExtcapDir = WiresharkDir + '\extcap'
 
 setup(
     name='pyspinel',
@@ -49,5 +64,6 @@ setup(
         'pyserial',
         'ipaddress',
     ],
-    scripts=['spinel-cli.py', 'sniffer.py']
+    scripts=['spinel-cli.py', 'sniffer.py', 'extcap_ot.py', 'extcap_ot.bat'],
+    data_files=[(WiresharkExtcapDir, ['extcap_ot.py', 'extcap_ot.bat'])]
 )

--- a/setup.py
+++ b/setup.py
@@ -16,23 +16,42 @@
 #  limitations under the License.
 #
 from setuptools import setup, find_packages
-import sys
+from setuptools.command import install
+import shutil
 import os
+import sys
 
-WiresharkExtcapDir = ''
 
-if sys.platform.startswith('linux'):
-    WiresharkExtcapDir = os.popen('find /usr/ -type d -ipath *wireshark*extcap').read()
-    if WiresharkExtcapDir:
-        WiresharkExtcapDir = str(WiresharkExtcapDir).split()[0]
-elif sys.platform == 'darwin':
-    WiresharkExtcapDir = os.popen('find /Applications/ -type d -ipath *wireshark*extcap').read()
-    if WiresharkExtcapDir:
-        WiresharkExtcapDir = str(WiresharkExtcapDir).split()[0]
-elif sys.platform == 'win32':
-    WiresharkDir = input("Wireshark installation directory: ")
-    if WiresharkDir:
-        WiresharkExtcapDir = WiresharkDir + '\extcap'
+class _InstallCommand(install.install):
+    user_options = install.install.user_options + [
+        ('extcap-path=', None, 'Path to Wireshark extcap directory'),
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super(_InstallCommand, self).__init__(*args, **kwargs)
+        self.extcap_path = None
+
+    def run(self):
+        if self.extcap_path:
+            _copy_script('extcap_ot.py', self.extcap_path)
+            _copy_script('extcap_ot.bat', self.extcap_path)
+        else:
+            print('WARNING: Wireshark extcap is not installed. To install:', file=sys.stderr)
+            print('1. Get Wireshark extcap path from Wireshark -> About -> Folders -> Extcap path', file=sys.stderr)
+            print('2. Run setup.py with --extcap-path=<extcap path> if you are installing by executing setup.py',
+                  file=sys.stderr)
+            print('   or', file=sys.stderr)
+            print('   Provide --install-option="--extcap-path=<extcap path>" if you are installing by pip',
+                  file=sys.stderr)
+        super(_InstallCommand, self).run()
+
+
+def _copy_script(src, dest):
+    cwd = os.path.abspath(os.path.dirname(__file__))
+    src = os.path.join(cwd, src)
+    print(f'copying {src} -> {dest}')
+    shutil.copy2(src, dest)
+
 
 setup(
     name='pyspinel',
@@ -65,5 +84,5 @@ setup(
         'ipaddress',
     ],
     scripts=['spinel-cli.py', 'sniffer.py', 'extcap_ot.py', 'extcap_ot.bat'],
-    data_files=[(WiresharkExtcapDir, ['extcap_ot.py', 'extcap_ot.bat'])]
+    cmdclass={'install': _InstallCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ class _InstallCommand(install.install):
     def run(self):
         if self.extcap_path:
             _copy_script('extcap_ot.py', self.extcap_path)
-            _copy_script('extcap_ot.bat', self.extcap_path)
+            if sys.platform == 'win32':
+                _copy_script('extcap_ot.bat', self.extcap_path)
         else:
             print('WARNING: Wireshark extcap is not installed. To install:', file=sys.stderr)
             print('1. Get Wireshark extcap path from Wireshark -> About -> Folders -> Extcap path', file=sys.stderr)

--- a/sniffer.py
+++ b/sniffer.py
@@ -28,6 +28,8 @@
 import sys
 import optparse
 import time
+import os
+import threading
 from datetime import datetime
 
 import spinel.util as util
@@ -36,6 +38,10 @@ from spinel.const import SPINEL
 from spinel.codec import WpanApi
 from spinel.stream import StreamOpen
 from spinel.pcap import PcapCodec
+
+if sys.platform == 'win32':
+    import ctypes
+    import msvcrt
 
 # Nodeid is required to execute ot-ncp-ftd for its sim radio socket port.
 # This is maximum that works for MacOS.
@@ -73,16 +79,19 @@ def parse_args():
                           dest="channel", type="int", default=DEFAULT_CHANNEL)
 
     opt_parser.add_option('--crc', action='store_true',
-                          dest='crc', default=False )
+                          dest='crc', default=False)
 
     opt_parser.add_option('--rssi', action='store_true',
-                          dest='rssi', default=False )
+                          dest='rssi', default=False)
 
     opt_parser.add_option('--no-reset', action='store_true',
-                          dest='no_reset', default=False )
+                          dest='no_reset', default=False)
 
     opt_parser.add_option('--tap', action='store_true',
                           dest='tap', default=False)
+
+    opt_parser.add_option('--is-fifo', action='store_true',
+                          dest='is_fifo', default=False)
 
     return opt_parser.parse_args(args)
 
@@ -97,7 +106,7 @@ def sniffer_init(wpan_api, options):
         wpan_api.cmd_send(SPINEL.CMD_RESET)
         time.sleep(1)
 
-    result = wpan_api.prop_set_value(SPINEL.PROP_PHY_ENABLED, 1)
+    wpan_api.prop_set_value(SPINEL.PROP_PHY_ENABLED, 1)
 
     result = wpan_api.prop_set_value(SPINEL.PROP_MAC_FILTER_MODE, SPINEL.MAC_FILTER_MODE_MONITOR)
     if result is None:
@@ -112,6 +121,35 @@ def sniffer_init(wpan_api, options):
         return False
 
     return True
+
+
+FIFO_CHECK_INTERVAL = 0.1
+
+def check_fifo(fifo):
+    if sys.platform == 'win32':
+        kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+        handle = msvcrt.get_osfhandle(fifo.fileno())
+        data = b''
+        p_data = ctypes.c_char_p(data)
+        written = ctypes.c_ulong(0)
+        while True:
+            time.sleep(FIFO_CHECK_INTERVAL)
+            if not kernel32.WriteFile(handle, p_data, 0, ctypes.byref(written), None):
+                error = ctypes.get_last_error()
+                if error in (
+                        0xe8,  # ERROR_NO_DATA
+                        0xe9,  # ERROR_PIPE_NOT_CONNECTED
+                ):
+                    os._exit(0)
+                else:
+                    raise ctypes.WinError(error)
+    else:
+        while True:
+            time.sleep(FIFO_CHECK_INTERVAL)
+            try:
+                os.stat(fifo.name)
+            except OSError:
+                os._exit(0)
 
 def main():
     """ Top-level main for sniffer host-side tool. """
@@ -140,7 +178,8 @@ def main():
             stream_descriptor = " ".join(remaining_args)
 
     stream = StreamOpen(stream_type, stream_descriptor, False, options.baudrate)
-    if stream is None: exit()
+    if stream is None:
+        exit()
     wpan_api = WpanApi(stream, options.nodeid)
     result = sniffer_init(wpan_api, options)
     if not result:
@@ -155,7 +194,7 @@ def main():
     if options.hex:
         hdr = util.hexify_str(hdr)+"\n"
 
-    if (options.output):
+    if options.output:
         output = open(options.output, 'wb')
     elif hasattr(sys.stdout, 'buffer'):
         output = sys.stdout.buffer
@@ -164,6 +203,9 @@ def main():
 
     output.write(hdr)
     output.flush()
+
+    if options.is_fifo:
+        threading.Thread(target=check_fifo, args=(output,)).start()
 
     epoch = datetime(1970, 1, 1)
     timebase = datetime.utcnow() - epoch
@@ -237,6 +279,7 @@ def main():
         wpan_api.stream.close()
 
     output.close()
+
 
 if __name__ == "__main__":
     main()

--- a/sniffer.py
+++ b/sniffer.py
@@ -93,6 +93,9 @@ def parse_args():
     opt_parser.add_option('--is-fifo', action='store_true',
                           dest='is_fifo', default=False)
 
+    opt_parser.add_option('--use-host-timestamp', action='store_true',
+                          dest='use_host_timestamp', default=False)
+
     return opt_parser.parse_args(args)
 
 def sniffer_init(wpan_api, options):
@@ -157,6 +160,9 @@ def main():
 
     if options.debug:
         CONFIG.debug_set_level(options.debug)
+
+    if options.use_host_timestamp:
+        print('WARNING: Using host timestamp, may be inaccurate', file=sys.stderr)
 
     # Set default stream to pipe
     stream_type = 'p'
@@ -264,6 +270,11 @@ def main():
 
                     if options.rssi:
                         sys.stderr.write("WARNING: failed to display RSSI, please update the NCP version\n")
+
+                if options.use_host_timestamp:
+                    timestamp = round(time.time() * 1000000)
+                    timestamp_sec = timestamp // 1000000
+                    timestamp_usec = timestamp % 1000000
 
                 pkt = pcap.encode_frame(pkt, int(timestamp_sec), timestamp_usec, options.rssi, options.crc, metadata)
 

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -843,6 +843,8 @@ class WpanApi(SpinelCodec):
         self.stream = stream
         self.nodeid = nodeid
 
+        self.timeout = TIMEOUT_PROP
+
         self.use_hdlc = use_hdlc
         if self.use_hdlc:
             self.hdlc = Hdlc(self.stream)
@@ -977,9 +979,12 @@ class WpanApi(SpinelCodec):
             item = None
         return item
 
-    def queue_wait_for_prop(self, _prop, tid=SPINEL.HEADER_DEFAULT, timeout=TIMEOUT_PROP):
+    def queue_wait_for_prop(self, _prop, tid=SPINEL.HEADER_DEFAULT, timeout=None):
         if _prop is None:
             return None
+
+        if timeout is None:
+            timeout = self.timeout
 
         processed_queue = queue.Queue()
         timeout_time = time.time() + timeout

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -839,11 +839,11 @@ if codec is not None:
 class WpanApi(SpinelCodec):
     """ Helper class to format wpan command packets """
 
-    def __init__(self, stream, nodeid, use_hdlc=FEATURE_USE_HDLC):
+    def __init__(self, stream, nodeid, use_hdlc=FEATURE_USE_HDLC, timeout=TIMEOUT_PROP):
         self.stream = stream
         self.nodeid = nodeid
 
-        self.timeout = TIMEOUT_PROP
+        self.timeout = timeout
 
         self.use_hdlc = use_hdlc
         if self.use_hdlc:

--- a/spinel/hdlc.py
+++ b/spinel/hdlc.py
@@ -18,6 +18,7 @@
 
 import binascii
 import logging
+import sys
 
 from struct import pack
 

--- a/spinel/hdlc.py
+++ b/spinel/hdlc.py
@@ -17,8 +17,6 @@
 """ High-Level Data Link Control (HDLC) module. """
 
 import binascii
-import logging
-import sys
 
 from struct import pack
 

--- a/spinel/pcap.py
+++ b/spinel/pcap.py
@@ -17,6 +17,7 @@
 """ Module to provide codec utilities for .pcap formatters. """
 
 import struct
+import binascii
 
 PCAP_MAGIC_NUMBER = 0xA1B2C3D4
 PCAP_VERSION_MAJOR = 2

--- a/spinel/pcap.py
+++ b/spinel/pcap.py
@@ -17,7 +17,6 @@
 """ Module to provide codec utilities for .pcap formatters. """
 
 import struct
-import binascii
 
 PCAP_MAGIC_NUMBER = 0xA1B2C3D4
 PCAP_VERSION_MAJOR = 2

--- a/spinel/stream.py
+++ b/spinel/stream.py
@@ -21,7 +21,6 @@ Also includes adapter implementations for serial, socket, and pipes.
 
 import sys
 import binascii
-import logging
 import time
 import traceback
 
@@ -29,7 +28,6 @@ import subprocess
 import socket
 import serial
 
-import spinel.util
 import spinel.config as CONFIG
 
 
@@ -57,8 +55,7 @@ class StreamSerial(IStream):
             self.serial = serial.Serial(dev, baudrate)
         except Exception as e:
             CONFIG.LOGGER.error(f"Couldn't open {dev} {str(e)}")
-            self.close()
-            traceback.print_exc()
+            raise
 
     def write(self, data):
         self.serial.write(data)

--- a/spinel/stream.py
+++ b/spinel/stream.py
@@ -55,8 +55,9 @@ class StreamSerial(IStream):
     def __init__(self, dev, baudrate=115200):
         try:
             self.serial = serial.Serial(dev, baudrate)
-        except:
-            CONFIG.LOGGER.error("Couldn't open " + dev)
+        except Exception as e:
+            CONFIG.LOGGER.error(f"Couldn't open {dev} {str(e)}")
+            self.close()
             traceback.print_exc()
 
     def write(self, data):
@@ -70,6 +71,9 @@ class StreamSerial(IStream):
             CONFIG.LOGGER.debug("RX Raw: " + binascii.hexlify(pkt).decode('utf-8'))
 
         return pkt[0]
+
+    def close(self):
+        self.serial.close()
 
 
 class StreamSocket(IStream):


### PR DESCRIPTION
This PR provides a more user-friendly way to use OpenThread Sniffer, refer to the [example](https://github.com/wireshark/wireshark/blob/master/doc/extcap_example.py) provided by Wireshark.
You can see the effect in the draft of the [user guide](https://docs.google.com/document/d/1cyKamVzE41RQZuFvZHJJenm1VCMthl7CnB-FmZFAiyI/edit?usp=sharing).