### PR TITLE
[spinel-cli] fix invalid encoding in debug mode hexify

### DIFF
--- a/spinel/util.py
+++ b/spinel/util.py
@@ -27,10 +27,8 @@ def hexify_chr(s):
 def hexify_int(i): return "%02X" % i
 def hexify_bytes(data): return str(list(map(hexify_chr,data)))
 def hexify_str(s,delim=':'):
-    if (isinstance(s, str) or isinstance(s, unicode)) and sys.version_info.major == 2:
-        return delim.join(x.encode('hex') for x in s)
-    else:
-        return delim.join(str(binascii.hexlify(bytearray(x, "utf-8")))[2:-1] for x in s)
+    hex_str = binascii.b2a_hex(bytearray(s, "utf-8")).decode("utf-8")
+    return delim.join([hex_str[i:i+2] for i in range(0, len(hex_str), 2)])
 
 def pack_bytes(packet): return pack("%dB" % len(packet), *packet)
 def packed_to_array(packet): return list(map(ord, packet))

--- a/spinel/util.py
+++ b/spinel/util.py
@@ -27,10 +27,10 @@ def hexify_chr(s):
 def hexify_int(i): return "%02X" % i
 def hexify_bytes(data): return str(list(map(hexify_chr,data)))
 def hexify_str(s,delim=':'):
-    if isinstance(s, str) and sys.version_info[0] == 2:
+    if (isinstance(s, str) or isinstance(s, unicode)) and sys.version_info.major == 2:
         return delim.join(x.encode('hex') for x in s)
     else:
-        return delim.join(str(binascii.hexlify(bytearray([x])))[2:-1] for x in s)
+        return delim.join(str(binascii.hexlify(bytearray(x, "utf-8")))[2:-1] for x in s)
 
 def pack_bytes(packet): return pack("%dB" % len(packet), *packet)
 def packed_to_array(packet): return list(map(ord, packet))


### PR DESCRIPTION
If the debug mode was entered using the `debug 1` command, sending any diag command would fail due to encoding error.