### PR TITLE
[logging] fix python issues with logging and use proper logger

### DIFF
--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -284,7 +284,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
                 pkt = cls.icmp_factory.from_bytes(value)
 
                 if CONFIG.DEBUG_LOG_PKT:
-                    logging.debug(pkt)
+                    CONFIG.LOGGER.debug(pkt)
 
                 timenow = int(round(time.time() * 1000)) & 0xFFFFFFFF
                 timestamp = (pkt.upper_layer_protocol.body.identifier << 16 | pkt.upper_layer_protocol.body.sequence_number)
@@ -301,7 +301,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
     @classmethod
     def log(cls, text):
         """ Common log handler. """
-        logging.info(text)
+        CONFIG.LOGGER.info(text)
 
     def parseline(self, line):
         cmd, arg, line = Cmd.parseline(self, line)
@@ -506,9 +506,9 @@ class SpinelCliCmd(Cmd, SpinelCodec):
 
     def default(self, line):
         if line[0] == "#":
-            logging.debug(line)
+            CONFIG.LOGGER.debug(line)
         else:
-            logging.info(line + ": command not found")
+            CONFIG.LOGGER.info(line + ": command not found")
             # exec(line)
 
     def do_debug(self, line):
@@ -2210,7 +2210,7 @@ def main():
     try:
         shell.cmdloop()
     except KeyboardInterrupt:
-        logging.info('\nCTRL+C Pressed')
+        CONFIG.LOGGER.info('\nCTRL+C Pressed')
 
     if shell.wpan_api:
         shell.wpan_api.stream.close()

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -660,25 +660,25 @@ class SpinelCommandHandler(SpinelCodec):
                 # Generic output
                 if isinstance(prop_value, str):
                     prop_value_str = util.hexify_str(prop_value)
-                    logging.debug("PROP_VALUE_%s [tid=%d]: %s = %s",
-                                  name, (tid & 0xF), prop_name, prop_value_str)
+                    CONFIG.LOGGER.debug("PROP_VALUE_%s [tid=%d]: %s = %s",
+                                        name, (tid & 0xF), prop_name, prop_value_str)
                 else:
                     prop_value_str = str(prop_value)
 
-                    logging.debug("PROP_VALUE_%s [tid=%d]: %s = %s",
-                                  name, (tid & 0xF), prop_name, prop_value_str)
+                    CONFIG.LOGGER.debug("PROP_VALUE_%s [tid=%d]: %s = %s",
+                                        name, (tid & 0xF), prop_name, prop_value_str)
 
                 # Extend output for certain properties.
                 if prop_id == SPINEL.PROP_LAST_STATUS:
-                    logging.debug(SPINEL_LAST_STATUS_MAP[prop_value])
+                    CONFIG.LOGGER.debug(SPINEL_LAST_STATUS_MAP[prop_value])
 
             if CONFIG.DEBUG_LOG_PKT:
                 if ((prop_id == SPINEL.PROP_STREAM_NET) or
                         (prop_id == SPINEL.PROP_STREAM_NET_INSECURE)):
-                    logging.debug("PROP_VALUE_" + name + ": " + prop_name)
+                    CONFIG.LOGGER.debug("PROP_VALUE_" + name + ": " + prop_name)
 
                 elif prop_id == SPINEL.PROP_STREAM_DEBUG:
-                    logging.debug("DEBUG: " + prop_value)
+                    CONFIG.LOGGER.debug("DEBUG: " + prop_value)
 
             if wpan_api:
                 wpan_api.queue_add(prop_id, prop_value, tid)
@@ -686,7 +686,7 @@ class SpinelCommandHandler(SpinelCodec):
                 print("no wpan_api")
         else:
             prop_name = "Property Unknown"
-            logging.info("\n%s (%i): ", prop_name, prop_id)
+            CONFIG.LOGGER.info("\n%s (%i): ", prop_name, prop_id)
 
     def PROP_VALUE_IS(self, wpan_api, payload, tid):
         self.handle_prop(wpan_api, "IS", payload, tid)
@@ -851,8 +851,8 @@ class WpanApi(SpinelCodec):
     def transact(self, command_id, payload=bytes(), tid=SPINEL.HEADER_DEFAULT):
         pkt = self.encode_packet(command_id, payload, tid)
         if CONFIG.DEBUG_LOG_SERIAL:
-            msg = "TX Pay: (%i) %s " % (len(pkt), binascii.hexlify(pkt))
-            logging.debug(msg)
+            msg = "TX Pay: (%i) %s " % (len(pkt), binascii.hexlify(pkt).decode('utf-8'))
+            CONFIG.LOGGER.debug(msg)
 
         if self.use_hdlc:
             pkt = self.hdlc.encode(pkt)
@@ -864,8 +864,8 @@ class WpanApi(SpinelCodec):
 
         if CONFIG.DEBUG_LOG_SERIAL:
             msg = "RX Pay: (%i) %s " % (
-                len(pkt), binascii.hexlify(pkt))
-            logging.debug(msg)
+                len(pkt), binascii.hexlify(pkt).decode('utf-8'))
+            CONFIG.LOGGER.debug(msg)
 
         length = len(pkt) - 2
         if length < 0:
@@ -889,11 +889,11 @@ class WpanApi(SpinelCodec):
         except Exception as _ex:
             print(traceback.format_exc())
             cmd_name = "CB_Unknown"
-            logging.info("\n%s (%i): ", cmd_name, cmd_id)
+            CONFIG.LOGGER.info("\n%s (%i): ", cmd_name, cmd_id)
 
         if CONFIG.DEBUG_CMD_RESPONSE:
-            logging.info("\n%s (%i): ", cmd_name, cmd_id)
-            logging.info("===> %s", util.hexify_str(payload))
+            CONFIG.LOGGER.info("\n%s (%i): ", cmd_name, cmd_id)
+            CONFIG.LOGGER.info("===> %s", binascii.hexlify(payload).decode('utf-8'))
 
     def stream_tx(self, pkt):
         # Encapsulate lagging and Framer support in self.stream class.

--- a/spinel/config.py
+++ b/spinel/config.py
@@ -68,7 +68,6 @@ logging.config.dictConfig({
     }
 })
 
-
 def debug_set_level(level):
     """ Set logging level for spinel module. """
     global DEBUG_ENABLE, DEBUG_LOG_PROP

--- a/spinel/hdlc.py
+++ b/spinel/hdlc.py
@@ -101,7 +101,7 @@ class Hdlc(IStream):
             fcs = self.fcs16(byte, fcs)
 
         if CONFIG.DEBUG_HDLC:
-            logging.debug("RX Hdlc: " + binascii.hexlify(raw))
+            CONFIG.LOGGER.debug("RX Hdlc: " + binascii.hexlify(bytearray(raw)).decode('utf-8'))
 
         if fcs != HDLC_FCS_GOOD:
             packet = None
@@ -139,7 +139,7 @@ class Hdlc(IStream):
         packet = pack("%dB" % len(packet), *packet)
 
         if CONFIG.DEBUG_HDLC:
-            logging.debug("TX Hdlc: " + binascii.hexlify(packet))
+            CONFIG.LOGGER.debug("TX Hdlc: " + binascii.hexlify(bytearray(packet)).decode('utf-8'))
         return packet
 
     def write(self, data):

--- a/spinel/stream.py
+++ b/spinel/stream.py
@@ -56,18 +56,18 @@ class StreamSerial(IStream):
         try:
             self.serial = serial.Serial(dev, baudrate)
         except:
-            logging.error("Couldn't open " + dev)
+            CONFIG.LOGGER.error("Couldn't open " + dev)
             traceback.print_exc()
 
     def write(self, data):
         self.serial.write(data)
         if CONFIG.DEBUG_STREAM_TX:
-            logging.debug("TX Raw: " + binascii.hexlify(data))
+            CONFIG.LOGGER.debug("TX Raw: " + binascii.hexlify(data).decode('utf-8'))
 
     def read(self, size=1):
         pkt = self.serial.read(size)
         if CONFIG.DEBUG_STREAM_RX:
-            logging.debug("RX Raw: " + binascii.hexlify(pkt))
+            CONFIG.LOGGER.debug("RX Raw: " + binascii.hexlify(pkt).decode('utf-8'))
 
         return pkt[0]
 
@@ -83,12 +83,12 @@ class StreamSocket(IStream):
     def write(self, data):
         self.sock.send(data)
         if CONFIG.DEBUG_STREAM_TX:
-            logging.debug("TX Raw: " + binascii.hexlify(data))
+            CONFIG.LOGGER.debug("TX Raw: " + binascii.hexlify(data).decode('utf-8'))
 
     def read(self, size=1):
         pkt = self.sock.recv(size)
         if CONFIG.DEBUG_STREAM_RX:
-            logging.debug("RX Raw: " + binascii.hexlify(pkt))
+            CONFIG.LOGGER.debug("RX Raw: " + binascii.hexlify(pkt).decode('utf-8'))
 
         return pkt[0]
 
@@ -105,7 +105,7 @@ class StreamPipe(IStream):
                                          stdout=subprocess.PIPE,
                                          stderr=sys.stderr)
         except:
-            logging.error("Couldn't open " + filename)
+            CONFIG.LOGGER.error("Couldn't open " + filename)
             traceback.print_exc()
 
     def __del__(self):
@@ -113,8 +113,8 @@ class StreamPipe(IStream):
 
     def write(self, data):
         if CONFIG.DEBUG_STREAM_TX:
-            logging.debug("TX Raw: (%d) %s",
-                          len(data), binascii.hexlify(data))
+            CONFIG.LOGGER.debug("TX Raw: (%d) %s",
+                          len(data), binascii.hexlify(data).decode('utf-8'))
         self.pipe.stdin.write(data)
         self.pipe.stdin.flush()
         # let the NCP process UART events first
@@ -124,7 +124,7 @@ class StreamPipe(IStream):
         """ Blocking read on stream object """
         pkt = self.pipe.stdout.read(size)
         if CONFIG.DEBUG_STREAM_RX:
-            logging.debug("RX Raw: " + binascii.hexlify(pkt))
+            CONFIG.LOGGER.debug("RX Raw: " + binascii.hexlify(pkt).decode('utf-8'))
         if not pkt:
             sys.exit(0)
 

--- a/spinel/tun.py
+++ b/spinel/tun.py
@@ -60,7 +60,7 @@ class TunInterface(object):
         self.__start_tun_thread()
 
     def __init_osx(self):
-        logging.info("TUN: Starting osx " + self.ifname)
+        CONFIG.LOGGER.info("TUN: Starting osx " + self.ifname)
         filename = "/dev/" + self.ifname
         self.tun = os.open(filename, os.O_RDWR)
         self.fd = self.tun
@@ -69,7 +69,7 @@ class TunInterface(object):
         self.addr_del("fe80::1")
 
     def __init_linux(self):
-        logging.info("TUN: Starting linux " + self.ifname)
+        CONFIG.LOGGER.info("TUN: Starting linux " + self.ifname)
         self.tun = open("/dev/net/tun", "r+b")
         self.fd = self.tun.fileno()
 
@@ -116,8 +116,8 @@ class TunInterface(object):
         #gWpanApi.ip_send(packet)
         # os.write(self.fd, packet)    # Loop back
         if CONFIG.DEBUG_TUN:
-            logging.debug("\nTUN: TX (" + str(len(packet)) +
-                          ") " + util.hexify_str(packet))
+            CONFIG.LOGGER.debug("\nTUN: TX (" + str(len(packet)) +
+                                ") " + util.hexify_str(packet))
 
     def __run_tun_thread(self):
         while self.fd:
@@ -126,14 +126,14 @@ class TunInterface(object):
                 if ready_fd == self.fd:
                     packet = os.read(self.fd, 4000)
                     if CONFIG.DEBUG_TUN:
-                        logging.debug("\nTUN: RX (" + str(len(packet)) + ") " +
-                                      util.hexify_str(packet))
+                        CONFIG.LOGGER.debug("\nTUN: RX (" + str(len(packet)) + ") " +
+                                            util.hexify_str(packet))
                     self.write(packet)
             except:
                 traceback.print_exc()
                 break
 
-        logging.info("TUN: exiting")
+        CONFIG.LOGGER.info("TUN: exiting")
         if self.fd:
             os.close(self.fd)
             self.fd = None


### PR DESCRIPTION
I've noticed that currently, **pyspinel** does not work with a debug level higher than 0.
This was partially fixed by #72 but then #73 reintroduce the problem.

**Problem nr 1** Casting

For example if you run the pyspinel with the highest verbosity:
```
ludu@ludu:~/git/pyspinel$ sudo python3 spinel-cli.py -u /dev/ttyACM0 -d 5
DEBUG_ENABLE = 5
Opening serial to /dev/ttyACM0 @ 115200
PROP_VALUE_SET [tid=1]: IPv6_ICMP_PING_OFFLOAD
Traceback (most recent call last):
  File "spinel-cli.py", line 2287, in <module>
    main()
  File "spinel-cli.py", line 2276, in main
    shell = SpinelCliCmd(stream, nodeid=options.nodeid)
  File "spinel-cli.py", line 190, in __init__
    self.prop_set_value(SPINEL.PROP_IPv6_ICMP_PING_OFFLOAD, 1)
  File "spinel-cli.py", line 330, in prop_set_value
    return self.wpan_api.prop_set_value(prop_id, value, py_format)
  File "/home/ludu/git/pyspinel/spinel/codec.py", line 1106, in prop_set_value
    value, py_format, tid)
  File "/home/ludu/git/pyspinel/spinel/codec.py", line 1078, in __prop_change_value
    pay = self.encode_i(prop_id)
  File "/home/ludu/git/pyspinel/spinel/codec.py", line 295, in encode_i
    result = result + pack("<B", value)
TypeError: must be str, not bytes
```
I have fixed this and other such problems where helify returns bytes rather than expected string.

**Problem nr 2** Debug logs are not visible

Despite the logging module configuration sets logging level to DEBUG (inside *config.py*), this does not seem to work. I'm not the python expert, but my solution was to use `spinel` logger (`CONFIG.LOGGER`) rather than the default *logging* logger, within all modules.

Apparently it also solves #6 from 2.5 years ago :)

**Result**

```
spinel-cli > state
detached
Done
spinel-cli > debug 1
DEBUG_ENABLE = 1
spinel-cli > state
PROP_VALUE_GET [tid=1]: NET_ROLE
PROP_VALUE_IS [tid=1]: NET_ROLE = 0
detached
Done
spinel-cli > debug 3
DEBUG_ENABLE = 3
spinel-cli > state
PROP_VALUE_GET [tid=1]: NET_ROLE
TX Pay: (3) 810243 
RX Pay: (4) 81064300 
PROP_VALUE_IS [tid=1]: NET_ROLE = 0
detached
Done
spinel-cli > debug 4
DEBUG_ENABLE = 4
spinel-cli > state
PROP_VALUE_GET [tid=1]: NET_ROLE
TX Pay: (3) 810243 
TX Hdlc: 7e810243d3d37e
RX Hdlc: 7e81064300dc777e
RX Pay: (4) 81064300 
PROP_VALUE_IS [tid=1]: NET_ROLE = 0
detached
Done
spinel-cli > debug 5
DEBUG_ENABLE = 5
spinel-cli > state
PROP_VALUE_GET [tid=1]: NET_ROLE
TX Pay: (3) 810243 
TX Hdlc: 7e810243d3d37e
TX Raw: 7e810243d3d37e
RX Raw: 7e
RX Raw: 81
RX Raw: 06
RX Raw: 43
RX Raw: 00
RX Raw: dc
RX Raw: 77
RX Raw: 7e
RX Hdlc: 7e81064300dc777e
RX Pay: (4) 81064300 
PROP_VALUE_IS [tid=1]: NET_ROLE = 0
detached
Done
```