### PR TITLE
[spinel-cli] fix problem with bufferinfo command

### DIFF
--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -554,8 +554,6 @@ class SpinelCliCmd(Cmd, SpinelCodec):
 
         result = self.prop_get_value(SPINEL.PROP_MSG_BUFFER_COUNTERS)
         if result != None:
-            result = result[0]
-
             print("total: %d" % result[0])
             print("free: %d" % result[1])
             print("6lo send: %d %d" % result[2:4])


### PR DESCRIPTION
This PR fixes the following error:

```
spinel-cli > bufferinfo
Traceback (most recent call last):
  File "spinel-cli.py", line 2347, in <module>
    main()
  File "spinel-cli.py", line 2339, in main
    shell.cmdloop()
  File "/usr/lib/python3.6/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python3.6/cmd.py", line 217, in onecmd
    return func(arg)
  File "spinel-cli.py", line 559, in do_bufferinfo
    print("total: %d" % result[0])
TypeError: 'int' object is not subscriptable
```