### PR TITLE
[spinel-cli] implement counters command

### DIFF
--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -791,6 +791,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
                 TxOther: 0
                 TxRetry: 0
                 TxErrCca: 0
+                TxAbort: 0
                 TxErrBusyChannel: 0
             RxTotal: 2
                 RxUnicast: 1
@@ -841,7 +842,8 @@ class SpinelCliCmd(Cmd, SpinelCodec):
                 print("    TxOther: %d" % counters_tx[10])
                 print("    TxRetry: %d" % counters_tx[11])
                 print("    TxErrCca: %d" % counters_tx[12])
-                print("    TxErrBusyChannel: %d" % counters_tx[13])
+                print("    TxAbort: %d" % counters_tx[13])
+                print("    TxErrBusyChannel: %d" % counters_tx[14])
                 print("RxTotal: %d" % counters_rx[0])
                 print("    RxUnicast: %d" % counters_rx[1])
                 print("    RxBroadcast: %d" % counters_rx[2])

--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -28,7 +28,7 @@ childtimeout       history       ncp-tun           routerdowngradethreshold
 clear              ifconfig      netdataregister   routerselectionjitter
 commissioner       ipaddr        networkidtimeout  routerupgradethreshold
 contextreusedelay  joiner        networkname       scan
-counter            keysequence   panid             state
+counters           keysequence   panid             state
 debug              leaderdata    parent            thread
 debug-mem          leaderweight  ping              v
 diag               macfilter     prefix            version
@@ -228,7 +228,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         'childtimeout',
         'commissioner',
         'contextreusedelay',
-        'counter',
+        'counters',
         'diag',
         'discover',
         'eidcache',
@@ -762,48 +762,129 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         """
         self.handle_property(line, SPINEL.PROP_THREAD_CONTEXT_REUSE_DELAY, 'L')
 
-    def do_counter(self, line):
+    def do_counters(self, line):
         """
-        counter
+        counters
 
             Get the supported counter names.
 
-            >counter
+            >counters
             mac
+            mle
             Done
 
-        counter <countername>
+        counters <countername>
 
             Get the counter value.
 
-            >counter mac
+            > counters mac
             TxTotal: 10
-            TxAckRequested: 4
-            TxAcked: 4
-            TxNoAckRequested: 6
-            TxData: 10
-            TxDataPoll: 0
-            TxBeacon: 0
-            TxBeaconRequest: 0
-            TxOther: 0
-            TxRetry: 0
-            TxErrCca: 0
-            RxTotal: 11
-            RxData: 11
-            RxDataPoll: 0
-            RxBeacon: 0
-            RxBeaconRequest: 0
-            RxOther: 0
-            RxWhitelistFiltered: 0
-            RxDestAddrFiltered: 0
-            RxErrNoFrame: 0
-            RxErrNoUnknownNeighbor: 0
-            RxErrInvalidSrcAddr: 0
-            RxErrSec: 0
-            RxErrFcs: 0
-            RxErrOther: 0
+                TxUnicast: 3
+                TxBroadcast: 7
+                TxAckRequested: 3
+                TxAcked: 3
+                TxNoAckRequested: 7
+                TxData: 10
+                TxDataPoll: 0
+                TxBeacon: 0
+                TxBeaconRequest: 0
+                TxOther: 0
+                TxRetry: 0
+                TxErrCca: 0
+                TxErrBusyChannel: 0
+            RxTotal: 2
+                RxUnicast: 1
+                RxBroadcast: 1
+                RxData: 2
+                RxDataPoll: 0
+                RxBeacon: 0
+                RxBeaconRequest: 0
+                RxOther: 0
+                RxAddressFiltered: 0
+                RxDestAddrFiltered: 0
+                RxDuplicated: 0
+                RxErrNoFrame: 0
+                RxErrNoUnknownNeighbor: 0
+                RxErrInvalidSrcAddr: 0
+                RxErrSec: 0
+                RxErrFcs: 0
+                RxErrOther: 0
+            Done
+            > counters mle
+            Role Disabled: 0
+            Role Detached: 1
+            Role Child: 0
+            Role Router: 0
+            Role Leader: 1
+            Attach Attempts: 1
+            Partition Id Changes: 1
+            Better Partition Attach Attempts: 0
+            Parent Changes: 0
+            Done
         """
-        pass
+        if line == "mac":
+            result = self.prop_get_value(SPINEL.PROP_CNTR_ALL_MAC_COUNTERS)
+            if result != None:
+                counters_tx = result[0][0]
+                counters_rx = result[1][0]
+
+                print("TxTotal: %d" % counters_tx[0])
+                print("    TxUnicast: %d" % counters_tx[1])
+                print("    TxBroadcast: %d" % counters_tx[2])
+                print("    TxAckRequested: %d" % counters_tx[3])
+                print("    TxAcked: %d" % counters_tx[4])
+                print("    TxNoAckRequested: %d" % counters_tx[5])
+                print("    TxData: %d" % counters_tx[6])
+                print("    TxDataPoll: %d" % counters_tx[7])
+                print("    TxBeacon: %d" % counters_tx[8])
+                print("    TxBeaconRequest: %d" % counters_tx[9])
+                print("    TxOther: %d" % counters_tx[10])
+                print("    TxRetry: %d" % counters_tx[11])
+                print("    TxErrCca: %d" % counters_tx[12])
+                print("    TxErrBusyChannel: %d" % counters_tx[13])
+                print("RxTotal: %d" % counters_rx[0])
+                print("    RxUnicast: %d" % counters_rx[1])
+                print("    RxBroadcast: %d" % counters_rx[2])
+                print("    RxData: %d" % counters_rx[3])
+                print("    RxDataPoll: %d" % counters_rx[4])
+                print("    RxBeacon: %d" % counters_rx[5])
+                print("    RxBeaconRequest: %d" % counters_rx[6])
+                print("    RxOther: %d" % counters_rx[7])
+                print("    RxAddressFiltered: %d" % counters_rx[8])
+                print("    RxDestAddrFiltered: %d" % counters_rx[9])
+                print("    RxDuplicated: %d" % counters_rx[10])
+                print("    RxErrNoFrame: %d" % counters_rx[11])
+                print("    RxErrNoUnknownNeighbor: %d" % counters_rx[12])
+                print("    RxErrInvalidSrcAddr: %d" % counters_rx[13])
+                print("    RxErrSec: %d" % counters_rx[14])
+                print("    RxErrFcs: %d" % counters_rx[15])
+                print("    RxErrOther: %d" % counters_rx[16])
+                print("Done")
+            else:
+                print("Error")
+
+        elif line == "mle":
+            result = self.prop_get_value(SPINEL.PROP_CNTR_MLE_COUNTERS)
+            if result != None:
+                print("Role Disabled: %d" % result[0])
+                print("Role Detached: %d" % result[1])
+                print("Role Child: %d" % result[2])
+                print("Role Router: %d" % result[3])
+                print("Role Leader: %d" % result[4])
+                print("Attach Attempts: %d" % result[5])
+                print("Partition Id Changes: %d" % result[6])
+                print("Better Partition Attach Attempts: %d" % result[7])
+                print("Parent Changes: %d" % result[8])
+                print("Done")
+            else:
+                print("Error")
+
+        elif line is None or line == "":
+            print("mac")
+            print("mle")
+            print("Done")
+        else:
+            print("Error")
 
     def do_discover(self, line):
         """

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -637,6 +637,8 @@ class SpinelPropertyHandler(SpinelCodec):
     def PIB_MAC_SECURITY_ENABLED(self, _wpan_api, payload): pass
 
     def MSG_BUFFER_COUNTERS(self, _wpan_api, payload): return self.parse_fields(payload, "SSSSSSSSSSSSSSSS")
+    def ALL_MAC_COUNTERS(self, _wpan_api, payload): return self.parse_fields(payload, "t(A(L))t(A(L))")
+    def MLE_COUNTERS(self, _wpan_api, payload): return self.parse_fields(payload, "SSSSSSSSS")
 
     def NEST_STREAM_MFG(self, _wpan_api, payload): return self.parse_U(payload)
 
@@ -816,6 +818,9 @@ SPINEL_PROP_DISPATCH = {
     SPINEL.PROP_PIB_15_4_MAC_SECURITY_ENABLED: WPAN_PROP_HANDLER.PIB_MAC_SECURITY_ENABLED,
 
     SPINEL.PROP_MSG_BUFFER_COUNTERS: WPAN_PROP_HANDLER.MSG_BUFFER_COUNTERS,
+
+    SPINEL.PROP_CNTR_ALL_MAC_COUNTERS: WPAN_PROP_HANDLER.ALL_MAC_COUNTERS,
+    SPINEL.PROP_CNTR_MLE_COUNTERS: WPAN_PROP_HANDLER.MLE_COUNTERS,
 
     SPINEL.PROP_NEST_STREAM_MFG: WPAN_PROP_HANDLER.NEST_STREAM_MFG
 }

--- a/spinel/const.py
+++ b/spinel/const.py
@@ -345,6 +345,62 @@ class SPINEL(object):
     #     `S`, (CoapClientMessages)     The number of messages in the CoAP client send queue.
     #     `S`  (CoapClientBuffers)      The number of buffers in the CoAP client send queue.
     PROP_MSG_BUFFER_COUNTERS = PROP_CNTR__BEGIN + 400
+
+    # All MAC related counters.
+    # Format: t(A(L))t(A(L))  (Read-only)
+    #
+    # The transmit structure includes:
+    #
+    #     'L': TxTotal              (The total number of transmissions).
+    #     'L': TxUnicast            (The total number of unicast transmissions).
+    #     'L': TxBroadcast          (The total number of broadcast transmissions).
+    #     'L': TxAckRequested       (The number of transmissions with ack request).
+    #     'L': TxAcked              (The number of transmissions that were acked).
+    #     'L': TxNoAckRequested     (The number of transmissions without ack request).
+    #     'L': TxData               (The number of transmitted data).
+    #     'L': TxDataPoll           (The number of transmitted data poll).
+    #     'L': TxBeacon             (The number of transmitted beacon).
+    #     'L': TxBeaconRequest      (The number of transmitted beacon request).
+    #     'L': TxOther              (The number of transmitted other types of frames).
+    #     'L': TxRetry              (The number of retransmission times).
+    #     'L': TxErrCca             (The number of CCA failure times).
+    #     'L': TxErrAbort           (The number of frame transmission failures due to abort error).
+    #     'L': TxErrBusyChannel     (The number of frames that were dropped due to a busy channel).
+    #
+    # The receive structure includes:
+    #
+    #     'L': RxTotal              (The total number of received packets).
+    #     'L': RxUnicast            (The total number of unicast packets received).
+    #     'L': RxBroadcast          (The total number of broadcast packets received).
+    #     'L': RxData               (The number of received data).
+    #     'L': RxDataPoll           (The number of received data poll).
+    #     'L': RxBeacon             (The number of received beacon).
+    #     'L': RxBeaconRequest      (The number of received beacon request).
+    #     'L': RxOther              (The number of received other types of frames).
+    #     'L': RxAddressFiltered    (The number of received packets filtered by address filter (whitelist or blacklist)).
+    #     'L': RxDestAddrFiltered   (The number of received packets filtered by destination check).
+    #     'L': RxDuplicated         (The number of received duplicated packets).
+    #     'L': RxErrNoFrame         (The number of received packets with no or malformed content).
+    #     'L': RxErrUnknownNeighbor (The number of received packets from unknown neighbor).
+    #     'L': RxErrInvalidSrcAddr  (The number of received packets whose source address is invalid).
+    #     'L': RxErrSec             (The number of received packets with security error).
+    #     'L': RxErrFcs             (The number of received packets with FCS error).
+    #     'L': RxErrOther           (The number of received packets with other error).
+    PROP_CNTR_ALL_MAC_COUNTERS = PROP_CNTR__BEGIN + 401
+
+    # Thread MLE counters.
+    # Format: `SSSSSSSSS`  (Read-only)
+    #    'S': DisabledRole                  (The number of times device entered OT_DEVICE_ROLE_DISABLED role).
+    #    'S': DetachedRole                  (The number of times device entered OT_DEVICE_ROLE_DETACHED role).
+    #    'S': ChildRole                     (The number of times device entered OT_DEVICE_ROLE_CHILD role).
+    #    'S': RouterRole                    (The number of times device entered OT_DEVICE_ROLE_ROUTER role).
+    #    'S': LeaderRole                    (The number of times device entered OT_DEVICE_ROLE_LEADER role).
+    #    'S': AttachAttempts                (The number of attach attempts while device was detached).
+    #    'S': PartitionIdChanges            (The number of changes to partition ID).
+    #    'S': BetterPartitionAttachAttempts (The number of attempts to attach to a better partition).
+    #    'S': ParentChanges                 (The number of times device changed its parents).
+    PROP_CNTR_MLE_COUNTERS = PROP_CNTR__BEGIN + 402
+
     PROP_CNTR__END = 0x800
 
     PROP_NEST__BEGIN = 0x3BC0


### PR DESCRIPTION
This PR implements support for `counters` command.

Output is the same as with regular CLI application:
```
spinel-cli > counters mac
TxTotal: 7
    TxUnicast: 0
    TxBroadcast: 7
    TxAckRequested: 0
    TxAcked: 0
    TxNoAckRequested: 7
    TxData: 7
    TxDataPoll: 0
    TxBeacon: 0
    TxBeaconRequest: 0
    TxOther: 0
    TxRetry: 0
    TxErrCca: 0
    TxErrBusyChannel: 0
RxTotal: 0
    RxUnicast: 0
    RxBroadcast: 0
    RxData: 0
    RxDataPoll: 0
    RxBeacon: 0
    RxBeaconRequest: 0
    RxOther: 0
    RxAddressFiltered: 0
    RxDestAddrFiltered: 0
    RxDuplicated: 0
    RxErrNoFrame: 0
    RxErrNoUnknownNeighbor: 0
    RxErrInvalidSrcAddr: 0
    RxErrSec: 0
    RxErrFcs: 0
    RxErrOther: 0
Done
spinel-cli > counters mle
Role Disabled: 0
Role Detached: 1
Role Child: 0
Role Router: 0
Role Leader: 1
Attach Attempts: 1
Partition Id Changes: 1
Better Partition Attach Attempts: 0
Parent Changes: 0
Done
spinel-cli > counters
mac
mle
Done
```