### PR TITLE
[spinel-cli] extend spinel cli with vendor hooks module

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,27 @@ Done
 #### ncp-ll64
 
 Return the Link Local 64-bit IPv6 address for the node.
+
+
+## Vendor package
+
+Extension of spinel-cli by specific vendor properties and commands.
+Idea of creating vendor package is to create specific commands without interrupting in spinel core.
+Vendor module contain:
+
+| MODULE        |    DESCRIPTION                                     |
+|---------------|----------------------------------------------------|
+| vendor        | Module providing a specific vendor commands        |
+| const         | Module with constants for vendor spinel extension  |
+| codec         | Module providing a Vendor property handlers        |
+In each module is provided example how to add specific vendor codec and constant. 
+
+### Vendor commands
+
+#### help
+```bash
+spinel-cli > vendor help
+Available vendor commands:
+==============================================
+help
+```

--- a/README.md
+++ b/README.md
@@ -369,20 +369,22 @@ Return the Link Local 64-bit IPv6 address for the node.
 
 ## Vendor package
 
-Extension of spinel-cli by specific vendor properties and commands.
-Idea of creating vendor package is to create specific commands without interrupting in spinel core.
-Vendor module contain:
+Extension of the Spinel CLI with custom properties and commands.
+This plugin-like extension adds vendor-specific commands and properties to pyspinel in a way that does not impact the 
+implementation of core pyspinel functionalities.
+
+The vendor package contains the following modules:
 
 | MODULE        |    DESCRIPTION                                     |
 |---------------|----------------------------------------------------|
-| vendor        | Module providing a specific vendor commands        |
-| const         | Module with constants for vendor spinel extension  |
-| codec         | Module providing a Vendor property handlers        |
-In each module is provided example how to add specific vendor codec and constant. 
+| vendor        | Module that provides a specific vendor commands.   |
+| const         | Module with constants for vendor spinel extension. |
+| codec         | Module that provides a vendor property handlers.   |
+Each module comes with an example that shows how to add specific vendor codecs and constants.
 
 ### Vendor commands
 
-#### help
+The vendor package adds several vendor-specific pyspinel commands. Use the help command to list them all.
 ```bash
 spinel-cli > vendor help
 Available vendor commands:

--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -42,6 +42,7 @@ import sys
 import time
 import traceback
 import random
+import importlib
 
 import optparse
 
@@ -263,6 +264,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         'state',
         'thread',
         'version',
+        'vendor',
 
         # OpenThread Spinel-specific commands
         'ncp-ml64',
@@ -2253,7 +2255,12 @@ def main():
             stream_descriptor = " ".join(remaining_args)
 
     stream = StreamOpen(stream_type, stream_descriptor, options.verbose, options.baudrate)
-    shell = SpinelCliCmd(stream, nodeid=options.nodeid)
+    try:
+        vendor_ext = importlib.import_module('vendor.vendor')
+        cls = type(vendor_ext.VendorSpinelCliCmd.__name__, (SpinelCliCmd, vendor_ext.VendorSpinelCliCmd), {})
+        shell = cls(stream, nodeid=options.nodeid)
+    except ImportError:
+        shell = SpinelCliCmd(stream, nodeid=options.nodeid)
 
     try:
         shell.cmdloop()

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -24,6 +24,7 @@ import logging
 import threading
 import traceback
 import queue
+import importlib
 
 from struct import pack
 from struct import unpack
@@ -710,7 +711,14 @@ SPINEL_COMMAND_DISPATCH = {
     SPINEL.RSP_PROP_VALUE_REMOVED: WPAN_CMD_HANDLER.PROP_VALUE_REMOVED,
 }
 
-WPAN_PROP_HANDLER = SpinelPropertyHandler()
+try:
+    codec = importlib.import_module('vendor.codec')
+    cls = type(codec.VendorSpinelPropertyHandler.__name__, (SpinelPropertyHandler, codec.VendorSpinelPropertyHandler),
+               {'__name__': codec.VendorSpinelPropertyHandler.__name__})
+    WPAN_PROP_HANDLER = cls()
+except ImportError:
+    codec = None
+    WPAN_PROP_HANDLER = SpinelPropertyHandler()
 
 SPINEL_PROP_DISPATCH = {
     SPINEL.PROP_LAST_STATUS:           WPAN_PROP_HANDLER.LAST_STATUS,
@@ -820,6 +828,8 @@ SPINEL_PROP_DISPATCH = {
     SPINEL.PROP_NEST_STREAM_MFG: WPAN_PROP_HANDLER.NEST_STREAM_MFG
 }
 
+if codec is not None:
+    SPINEL_PROP_DISPATCH.update(codec.VENDOR_SPINEL_PROP_DISPATCH)
 
 class WpanApi(SpinelCodec):
     """ Helper class to format wpan command packets """

--- a/vendor/codec.py
+++ b/vendor/codec.py
@@ -1,3 +1,23 @@
+#
+#  Copyright (c) 2016-2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Module providing a Vendor property handlers.
+"""
+
 from spinel.codec import SpinelCodec
 from vendor.const import VENDOR_SPINEL
 
@@ -5,16 +25,15 @@ from vendor.const import VENDOR_SPINEL
 class VendorSpinelPropertyHandler(SpinelCodec):
     """
     Class to extend Spinel property Handler with new methods.
-    Methods define parsers for Vendor Hooks.
-    exapmle:
-    def VENDOR_HOOK_COMMAND(self, _wpan_api, payload): return self.parse_C(payload)
+    Methods define parsers for Vendor Hooks for exapmle:
+        `def VENDOR_HOOK_COMMAND(self, _wpan_api, payload): return self.parse_C(payload)`
     """
     pass
 
+
 WPAN_PROP_HANDLER = VendorSpinelPropertyHandler()
 
-#Parameter to extend SPINEL_PREP_DISPATCH with Vendor properties
-#example:
-#   VENDOR_SPINEL_PROP_DISPATCH = {VENDOR_SPINEL.PROP_VENDOR_HOOK: WPAN_PROP_HANDLER.VENDOR_HOOK_COMMAND}
+# Parameter to extend SPINEL_PREP_DISPATCH with Vendor properties for example:
+#   `VENDOR_SPINEL_PROP_DISPATCH = {VENDOR_SPINEL.PROP_VENDOR_HOOK: WPAN_PROP_HANDLER.VENDOR_HOOK_COMMAND}`
 VENDOR_SPINEL_PROP_DISPATCH = {}
 

--- a/vendor/codec.py
+++ b/vendor/codec.py
@@ -26,7 +26,7 @@ class VendorSpinelPropertyHandler(SpinelCodec):
     """
     Class to extend Spinel property Handler with new methods.
     Methods define parsers for Vendor Hooks for exapmle:
-        `def VENDOR_HOOK_COMMAND(self, _wpan_api, payload): return self.parse_C(payload)`
+        `def VENDOR_HOOK_PROPERTY(self, _wpan_api, payload): return self.parse_C(payload)`
     """
     pass
 
@@ -34,6 +34,6 @@ class VendorSpinelPropertyHandler(SpinelCodec):
 WPAN_PROP_HANDLER = VendorSpinelPropertyHandler()
 
 # Parameter to extend SPINEL_PREP_DISPATCH with Vendor properties for example:
-#   `VENDOR_SPINEL_PROP_DISPATCH = {VENDOR_SPINEL.PROP_VENDOR_HOOK: WPAN_PROP_HANDLER.VENDOR_HOOK_COMMAND}`
+#   `VENDOR_SPINEL_PROP_DISPATCH = {VENDOR_SPINEL.PROP_VENDOR_HOOK: WPAN_PROP_HANDLER.VENDOR_HOOK_PROPERTY}`
 VENDOR_SPINEL_PROP_DISPATCH = {}
 

--- a/vendor/codec.py
+++ b/vendor/codec.py
@@ -1,0 +1,20 @@
+from spinel.codec import SpinelCodec
+from vendor.const import VENDOR_SPINEL
+
+
+class VendorSpinelPropertyHandler(SpinelCodec):
+    """
+    Class to extend Spinel property Handler with new methods.
+    Methods define parsers for Vendor Hooks.
+    exapmle:
+    def VENDOR_HOOK_COMMAND(self, _wpan_api, payload): return self.parse_C(payload)
+    """
+    pass
+
+WPAN_PROP_HANDLER = VendorSpinelPropertyHandler()
+
+#Parameter to extend SPINEL_PREP_DISPATCH with Vendor properties
+#example:
+#   VENDOR_SPINEL_PROP_DISPATCH = {VENDOR_SPINEL.PROP_VENDOR_HOOK: WPAN_PROP_HANDLER.VENDOR_HOOK_COMMAND}
+VENDOR_SPINEL_PROP_DISPATCH = {}
+

--- a/vendor/const.py
+++ b/vendor/const.py
@@ -1,0 +1,10 @@
+class VENDOR_SPINEL(object):
+    """
+    Class to extend SPINEL constants variable
+    example:
+    PROP_VENDOR__BEGIN = 0x3C00
+
+    PROP_VENDOR_HOOK = PROP_VENDOR__BEGIN + 0
+    PROP_VENDOR__END = 0x4000
+    """
+    pass

--- a/vendor/const.py
+++ b/vendor/const.py
@@ -1,10 +1,29 @@
+#
+#  Copyright (c) 2016-2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Module with vendor constants for vendor spinel extension.
+"""
+
 class VENDOR_SPINEL(object):
     """
-    Class to extend SPINEL constants variable
-    example:
-    PROP_VENDOR__BEGIN = 0x3C00
+    Class to extend SPINEL constant variables for example:
+        PROP_VENDOR__BEGIN = 0x3C00
 
-    PROP_VENDOR_HOOK = PROP_VENDOR__BEGIN + 0
-    PROP_VENDOR__END = 0x4000
+        PROP_VENDOR_HOOK = PROP_VENDOR__BEGIN + 0
+        PROP_VENDOR__END = 0x4000
     """
     pass

--- a/vendor/vendor.py
+++ b/vendor/vendor.py
@@ -1,0 +1,20 @@
+from vendor.const import VENDOR_SPINEL
+
+class VendorSpinelCliCmd():
+    """
+    Extended Vendor Spinel Cli with vendor hooks commands
+    INPUT:
+            spinel-cli > vendor help
+    OUTPUT:
+            Available commands from XYZ Vendor:
+            ==============================================
+            help
+    """
+    vendor_command_names = ['help']
+
+    def do_vendor(self, line):
+        params = line.split(" ")
+        if params[0] == 'help':
+            self.print_topics(
+            "\nAvailable commands from XYZ Vendor:",
+            VendorSpinelCliCmd.vendor_command_names, 15, 30)

--- a/vendor/vendor.py
+++ b/vendor/vendor.py
@@ -1,12 +1,33 @@
+#
+#  Copyright (c) 2016-2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Module providing a specific vendor commands.
+"""
+
+
 from vendor.const import VENDOR_SPINEL
 
 class VendorSpinelCliCmd():
     """
-    Extended Vendor Spinel Cli with vendor hooks commands
+    Extended Vendor Spinel Cli with vendor hooks commands.
     INPUT:
             spinel-cli > vendor help
     OUTPUT:
-            Available commands from XYZ Vendor:
+            Available vendor commands:
             ==============================================
             help
     """
@@ -16,5 +37,5 @@ class VendorSpinelCliCmd():
         params = line.split(" ")
         if params[0] == 'help':
             self.print_topics(
-            "\nAvailable commands from XYZ Vendor:",
+            "\nAvailable vendor commands:",
             VendorSpinelCliCmd.vendor_command_names, 15, 30)


### PR DESCRIPTION
Create new vendor module to maintain and use unique Vendor Spinel commnads.
Changes in code don't affect for users without vendor module.
vendor/vendor.py -> definition of unique vendor commands
vendor/const.py -> definition of vendor property constants
vendor/codec.pt -> definition of Spinel Handler and addition of mapping SPINEL_PROP_DISPATCH : WPAN_PROP_HANDLER