### PR TITLE
[pretty] fix yapf version to 0.29.0

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -29,7 +29,7 @@
 
 set -e
 
-python3 -m pip install yapf
+python3 -m pip install yapf==0.29.0
 
 ./script/make-pretty check
 


### PR DESCRIPTION
v0.30.0 (released on 2020-04-23) introduces formatting changes that
are not compatible with v0.29.0.