### PR TITLE
[spinel-cli] add vendor path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ $ sudo python3 setup.py install
 
     -d <DEBUG_LEVEL>, --debug=<DEBUG_LEVEL>
         Specify the debug level.
+
+    --vendor-path
+        Provide a custom location of the vendor package. If not specified, the
+        default location will be used (the vendor package shipped with the
+        pyspinel installation).
+        Note: The vendor package location can also be specified with
+        SPINEL_VENDOR_PATH environment variable.
 ```
 
 ## Quick start
@@ -367,6 +374,8 @@ The vendor package contains the following modules:
 | codec  | Module that provides a vendor property handlers.   |
 
 Each module comes with an example that shows how to add specific vendor codecs and constants.
+
+By default, pyspinel will use the vendor package shipped with pyspinel installation. You can provide a custom vendor package location with --vendor-path option or SPINEL_VENDOR_PATH environment variable.
 
 ### Vendor commands
 

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -822,15 +822,7 @@ SPINEL_COMMAND_DISPATCH = {
     SPINEL.RSP_PROP_VALUE_REMOVED: WPAN_CMD_HANDLER.PROP_VALUE_REMOVED,
 }
 
-try:
-    codec = importlib.import_module('vendor.codec')
-    cls = type(codec.VendorSpinelPropertyHandler.__name__,
-               (SpinelPropertyHandler, codec.VendorSpinelPropertyHandler),
-               {'__name__': codec.VendorSpinelPropertyHandler.__name__})
-    WPAN_PROP_HANDLER = cls()
-except ImportError:
-    codec = None
-    WPAN_PROP_HANDLER = SpinelPropertyHandler()
+WPAN_PROP_HANDLER = SpinelPropertyHandler()
 
 SPINEL_PROP_DISPATCH = {
     SPINEL.PROP_LAST_STATUS:
@@ -1023,9 +1015,6 @@ SPINEL_PROP_DISPATCH = {
         WPAN_PROP_HANDLER.NEST_STREAM_MFG
 }
 
-if codec is not None:
-    SPINEL_PROP_DISPATCH.update(codec.VENDOR_SPINEL_PROP_DISPATCH)
-
 
 class WpanApi(SpinelCodec):
     """ Helper class to format wpan command packets """
@@ -1043,6 +1032,13 @@ class WpanApi(SpinelCodec):
         self.use_hdlc = use_hdlc
         if self.use_hdlc:
             self.hdlc = Hdlc(self.stream)
+
+        # Hook vendor properties
+        try:
+            codec = importlib.import_module('vendor.codec')
+            SPINEL_PROP_DISPATCH.update(codec.VENDOR_SPINEL_PROP_DISPATCH)
+        except ImportError:
+            pass
 
         # PARSER state
         self.rx_pkt = []

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -1023,7 +1023,8 @@ class WpanApi(SpinelCodec):
                  stream,
                  nodeid,
                  use_hdlc=FEATURE_USE_HDLC,
-                 timeout=TIMEOUT_PROP):
+                 timeout=TIMEOUT_PROP,
+                 vendor_module=None):
         self.stream = stream
         self.nodeid = nodeid
 
@@ -1033,12 +1034,13 @@ class WpanApi(SpinelCodec):
         if self.use_hdlc:
             self.hdlc = Hdlc(self.stream)
 
-        # Hook vendor properties
-        try:
-            codec = importlib.import_module('vendor.codec')
-            SPINEL_PROP_DISPATCH.update(codec.VENDOR_SPINEL_PROP_DISPATCH)
-        except ImportError:
-            pass
+        if vendor_module:
+            # Hook vendor properties
+            try:
+                codec = importlib.import_module(vendor_module + '.codec')
+                SPINEL_PROP_DISPATCH.update(codec.VENDOR_SPINEL_PROP_DISPATCH)
+            except ImportError:
+                pass
 
         # PARSER state
         self.rx_pkt = []


### PR DESCRIPTION
Introduce a `--vendor-path` option which allows to provide a custom location of the vendor package. It is also possible to provide this location with `SPINEL_VENDOR_PATH` environmental variable.