### PR TITLE
[pypi] bump version to 1.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def _copy_script(src, dest):
 
 setup(
     name='pyspinel',
-    version='1.0.2',
+    version='1.0.3',
     description=
     'A Python interface to the OpenThread Network Co-Processor (NCP)',
     url='https://github.com/openthread/openthread',


### PR DESCRIPTION
@jwhui Seems it was very bad idea to create a package for pypi on Windows.. since line-endings are not correctly interpreted on Linux now.

I'm sorry for this issue and your additional effort but i need to upload a new version to pypi - this time from Linux and correct line-endings. Already verified locally. Pypi does not allow to replace the package, so we need to bumb the version again.