### PR TITLE
[codec] fix property value concatenation in debug message

### DIFF
--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -794,7 +794,7 @@ class SpinelCommandHandler(SpinelCodec):
                     CONFIG.LOGGER.debug("PROP_VALUE_" + name + ": " + prop_name)
 
                 elif prop_id == SPINEL.PROP_STREAM_DEBUG:
-                    CONFIG.LOGGER.debug("DEBUG: " + prop_value)
+                    CONFIG.LOGGER.debug("DEBUG: " + str(prop_value))
 
             if wpan_api:
                 wpan_api.queue_add(prop_id, prop_value, tid)


### PR DESCRIPTION
It fixes the exception:
```
python3 spinel-cli.py -u /dev/ttyACM1 -d 3
DEBUG_ENABLE = 3
PROP_VALUE_SET [tid=1]: IPv6_ICMP_PING_OFFLOAD
TX Pay: (4) 81036501 
RX Pay: (21) 8006704672616d696e67206572726f7220363a205b 
PROP_VALUE_IS [tid=0]: STREAM_DEBUG = b'Framing error 6: ['
Traceback (most recent call last):
  File "/home/luma/workspace/pyspinel/spinel/codec.py", line 1110, in parse_rx
    handler(self, payload, tid)
  File "/home/luma/workspace/pyspinel/spinel/codec.py", line 808, in PROP_VALUE_IS
    self.handle_prop(wpan_api, "IS", payload, tid)
  File "/home/luma/workspace/pyspinel/spinel/codec.py", line 797, in handle_prop
    CONFIG.LOGGER.debug("DEBUG: " + prop_value)
TypeError: can only concatenate str (not "bytes") to str

```
