### PR TITLE
[codec] handle failures when decoding utf-8

### DIFF
--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -122,7 +122,6 @@ class SpinelCodec(object):
         nullchar = b'\0'
         return payload[:payload.index(nullchar)].decode('utf-8')  # strip null
 
-
     @classmethod
     def parse_D(cls, payload):
         return payload

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -120,10 +120,8 @@ class SpinelCodec(object):
     @classmethod
     def parse_U(cls, payload):
         nullchar = b'\0'
-        if payload.find(nullchar) >= 0:
-            return payload[:payload.index(nullchar)].decode('utf-8')  # strip null
-        else:
-            return payload.decode('utf-8')
+        return payload[:payload.index(nullchar)].decode('utf-8')  # strip null
+
 
     @classmethod
     def parse_D(cls, payload):

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -119,13 +119,11 @@ class SpinelCodec(object):
 
     @classmethod
     def parse_U(cls, payload):
-        payload = payload.decode('utf-8')
-        nullchar = '\0'
-
+        nullchar = b'\0'
         if payload.find(nullchar) >= 0:
-            return payload[:payload.index(nullchar)]  # strip null
+            return payload[:payload.index(nullchar)].decode('utf-8')  # strip null
         else:
-            return payload
+            return payload.decode('utf-8')
 
     @classmethod
     def parse_D(cls, payload):


### PR DESCRIPTION
As said in https://github.com/openthread/pyspinel/issues/113, pyspinel failed to parse STREAM_LOG. 

This is because the format of STREAM_LOG is "UD" but pyspinel has no idea where the utf-8 part ends. Therefore it tries to decode the whole data as utf-8 then it fails when there's an invalid utf-8 character. In this PR I made pyspinel decode utf-8 as far as it can until it meets an invalid character. 