### PR TITLE
[spinel-cli] add handling for Windows readline.__doc__ is NoneType error

### DIFF
--- a/spinel-cli.py
+++ b/spinel-cli.py
@@ -173,7 +173,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             print("Module readline unavailable")
         else:
             import rlcompleter
-            if 'libedit' in readline.__doc__:
+            if readline.__doc__ and 'libedit' in readline.__doc__:
                 readline.parse_and_bind('bind ^I rl_complete')
             else:
                 readline.parse_and_bind('tab: complete')


### PR DESCRIPTION
For certain Windows installs, readline.doc is None. Check before trying to search for the phrase "libedit" inside it.