### PR TITLE
[codec] add decoding for allowlists that are passed back from the NCP

### DIFF
--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -509,7 +509,7 @@ class SpinelPropertyHandler(SpinelCodec):
                 return self.parse_fields(payload, format)
             except struct.error:
                 pass
-        return None        
+        return None
 
     def MAC_ALLOWLIST_ENABLED(self, _, payload):
         return self.parse_b(payload)

--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -21,6 +21,7 @@ Module providing a Spienl coder / decoder class.
 import binascii
 import time
 import logging
+import struct
 import threading
 import traceback
 import queue
@@ -502,7 +503,13 @@ class SpinelPropertyHandler(SpinelCodec):
         return self.parse_b(payload)
 
     def MAC_ALLOWLIST(self, _, payload):
-        pass
+        formats = ["A(t(EC))", "EC", "E"]
+        for format in formats:
+            try:
+                return self.parse_fields(payload, format)
+            except struct.error:
+                pass
+        return None        
 
     def MAC_ALLOWLIST_ENABLED(self, _, payload):
         return self.parse_b(payload)


### PR DESCRIPTION
Adding a fix for #124 by unpacking the various types of responses that come back from the MAC_ALLOWLIST property. Note that there are three different formats, so we try them from the most complex/involved to the least complex/involved.

1. Try to decode an array of structures composed of an EUI64 and an unsigned 8-bit integer (from querying the value)
2. If that fails, try to decode a single entry composed of an EUI64 and an unsigned 8-bit integer (from inserting a value)
3. If that fails, try to decode a single entry composed of only an EUI64 (from deleting an entry)
4. If all of these fail, return None