### PR TITLE
[codec] remove deprecated call to setDaemon

### DIFF
--- a/spinel/codec.py
+++ b/spinel/codec.py
@@ -604,7 +604,7 @@ class SpinelPropertyHandler(SpinelCodec):
         self.wpan_api = None
         self.__queue_prefix = queue.Queue()
         self.prefix_thread = threading.Thread(target=self.__run_prefix_handler)
-        self.prefix_thread.setDaemon(True)
+        self.prefix_thread.daemon = True
         self.prefix_thread.start()
 
     def handle_prefix_change(self, payload):


### PR DESCRIPTION
Switching the `setDaemon` call to use the `daemon` property instead. In looking at the history of the `daemon` property, it's been present in python for more than 10 years so this shouldn't require special handling.